### PR TITLE
fix: run build command in sequential

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "typescript": "~3.7.2"
   },
   "scripts": {
-    "build": "NODE_ENV=production npm-run-all -p build:*",
+    "build": "NODE_ENV=production npm-run-all -s build:css build:js",
     "build:css": "postcss src/tailwind.css -o src/index.css",
     "build:js": "react-scripts build",
     "commit": "git-cz",


### PR DESCRIPTION
Running the build command in parallel could led to the index.css to bot be created before being parsed by typescript (which then triggered an error `Cannot find file './index.css' in './src'.`)