### PR TITLE
fix: error message

### DIFF
--- a/src/components/verify/dropzone.tsx
+++ b/src/components/verify/dropzone.tsx
@@ -30,7 +30,8 @@ export const DropZone: React.FunctionComponent<DropZoneProps> = ({ onDocumentDro
     setFileErrorMsg("");
 
     reader.onerror = () => {
-      setFileErrorMsg(`The file uploaded is not a valid Open Attestation file, error: ${reader.error}`);
+      setFileErrorMsg(`The file uploaded is not a valid Open Attestation file.`);
+      console.error(reader.error);
     };
 
     reader.onload = () => {
@@ -38,10 +39,11 @@ export const DropZone: React.FunctionComponent<DropZoneProps> = ({ onDocumentDro
         if (reader.result && typeof reader.result === "string") {
           onDocumentDropped(JSON.parse(reader.result));
         } else {
-          setFileErrorMsg(`The file uploaded is not a valid Open Attestation file`);
+          setFileErrorMsg(`The file uploaded is not a valid Open Attestation file.`);
         }
       } catch (e) {
-        setFileErrorMsg(`The file uploaded is not a valid Open Attestation file, error: ${e.message}`);
+        setFileErrorMsg(`The file uploaded is not a valid Open Attestation file.`);
+        console.error(e);
       }
     };
 


### PR DESCRIPTION
### pr updates
- omit cryptic error message

### user story
- https://www.pivotaltracker.com/story/show/174465988

### some findings
- thought it was some utf-8 encoding issue (missing meta tag), but its not.
- interestingly, the error messages are reflected differently for different browsers, when using various file types (from left to right: chrome, firefox, safari)
- conclusion = to omit the message, log to console.error instead (not sure if its right) 😬

using jpg
![jpg](https://user-images.githubusercontent.com/4774314/92216699-3bf57280-eec9-11ea-9e94-558b4cdb2522.png)

using pdf
![pdf](https://user-images.githubusercontent.com/4774314/92216711-40219000-eec9-11ea-8c90-7cd45e4fcf05.png)

using mp4
![mp4](https://user-images.githubusercontent.com/4774314/92216704-3e57cc80-eec9-11ea-944c-a2cc49cb5cc8.png)
