### PR TITLE
fix: sticky footer

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,7 +4,7 @@ import { FaqPage } from "./components/faq/faq-page";
 import { HomePage } from "./components/home/home-page";
 import { PrivacyPolicyPage } from "./components/privacy/privacy-policy-page";
 import { Footer } from "./components/shared/footer";
-import { Header } from "./components/shared/header";
+import { Masthead } from "./components/shared/masthead";
 import { ScrollToTop } from "./components/shared/scroll-to-top";
 import { TermsPage } from "./components/terms/terms-page";
 import { VerifyPage } from "./components/verify/verify-page";
@@ -12,7 +12,7 @@ import { VerifyPage } from "./components/verify/verify-page";
 export const App: React.FunctionComponent = () => (
   <Router>
     <ScrollToTop />
-    <Header />
+    <Masthead />
     <main className="main">
       <Switch>
         <Route path="/privacy-policy">

--- a/src/components/faq/faq-page.tsx
+++ b/src/components/faq/faq-page.tsx
@@ -66,7 +66,7 @@ export const FaqPage: React.FunctionComponent = () => (
   <Section>
     <NavigationBar />
     <Separator />
-    <div className="container container-px py-4">
+    <div className="container py-4">
       <div className="flex flex-wrap">
         <div className="w-auto">
           <h2>Questions? Look here.</h2>
@@ -74,7 +74,7 @@ export const FaqPage: React.FunctionComponent = () => (
       </div>
     </div>
     <Container className="mb-8">
-      <div className="container container-px">
+      <div className="container">
         <div className="flex flex-wrap">
           <div className="w-full md:w-2/3">
             <FaqElement

--- a/src/components/home/home-page.tsx
+++ b/src/components/home/home-page.tsx
@@ -69,7 +69,7 @@ export const HomePage: React.FunctionComponent = () => {
     <Root>
       <Section>
         <NavigationBar />
-        <div className="container container-px py-12">
+        <div className="container py-12">
           <div className="flex flex-wrap items-center">
             <div className="w-full md:w-2/5 md:pr-4">
               <h1>An easy way to check and verify your certificates</h1>
@@ -88,7 +88,7 @@ export const HomePage: React.FunctionComponent = () => {
         </div>
       </Section>
       <Section>
-        <div className="container container-px py-12">
+        <div className="container py-12">
           <div className="flex flex-wrap items-center">
             <div className="w-full md:w-1/2 md:pr-4 md:order-2">
               <h1>How we can help</h1>
@@ -125,7 +125,7 @@ export const HomePage: React.FunctionComponent = () => {
         </div>
       </Section>
       <Section>
-        <div className="container container-px py-12">
+        <div className="container py-12">
           <div className="flex flex-wrap items-center">
             <div className="w-full md:w-1/3 md:pr-4">
               <h1>How we can help</h1>

--- a/src/components/privacy/privacy-policy-page.tsx
+++ b/src/components/privacy/privacy-policy-page.tsx
@@ -1,4 +1,3 @@
-// import styled from "@emotion/styled";
 import React from "react";
 import { Section, Separator } from "../shared/layout";
 import { NavigationBar } from "../shared/navigation-bar";

--- a/src/components/shared/masthead.tsx
+++ b/src/components/shared/masthead.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 
-export const Header: React.FunctionComponent = () => (
+export const Masthead: React.FunctionComponent = () => (
   <header className="sgds-masthead">
-    <div className="container container-px mx-auto">
+    <div className="container">
       <div className="flex flex-wrap">
         <div className="w-full">
           <a href="https://www.gov.sg" target="_blank" rel="noopener noreferrer">

--- a/src/components/shared/navigation-bar.tsx
+++ b/src/components/shared/navigation-bar.tsx
@@ -9,7 +9,7 @@ export const NavigationBar: React.FunctionComponent<NavigationBarProps> = ({
   onVerifyLinkClicked,
 }: NavigationBarProps) => {
   return (
-    <nav className="container container-px mx-auto pt-4">
+    <nav className="container pt-4">
       <div className="flex flex-wrap items-center">
         <div className="w-auto mr-auto">
           <Link to="/" className="font-roboto-bold text-4xl">

--- a/src/components/terms/terms-page.tsx
+++ b/src/components/terms/terms-page.tsx
@@ -1,4 +1,3 @@
-// import styled from "@emotion/styled";
 import React from "react";
 import { Section, Separator } from "../shared/layout";
 import { NavigationBar } from "../shared/navigation-bar";

--- a/src/components/verify/verify-page.tsx
+++ b/src/components/verify/verify-page.tsx
@@ -166,7 +166,7 @@ export const VerifyPage: React.FunctionComponent = () => {
       <Separator />
       {verificationStatus === Status.IDLE && (
         <>
-          <div className="container container-px py-4 text-center">
+          <div className="container py-4 text-center">
             <div className="flex flex-wrap">
               <div className="w-full">
                 <h2>Verify Documents</h2>
@@ -174,7 +174,7 @@ export const VerifyPage: React.FunctionComponent = () => {
               </div>
             </div>
           </div>
-          <div className="container container-px">
+          <div className="container">
             {loadDocumentStatus === Status.PENDING && (
               <div
                 className="bg-blue-100 border-t-4 border-blue-500 text-blue-700 p-4 w-full text-center mb-4 break-all"
@@ -206,7 +206,7 @@ export const VerifyPage: React.FunctionComponent = () => {
         </>
       )}
       {verificationStatus !== Status.IDLE && (
-        <div className="container container-px py-4">
+        <div className="container py-4">
           {issuer && (
             <div className="flex flex-wrap mb-4">
               <div className="w-full">

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -85,20 +85,19 @@
   @apply shadow-outline;
 }
 
-/* this will be the standardised lateral spacing for container */
-.container-px {
-  @apply px-4;
-}
-
+/* https://philipwalton.com/articles/normalizing-cross-browser-flexbox-bugs/ */
 #root {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
+  height: 100vh;
 }
 
-/* https://philipwalton.com/articles/normalizing-cross-browser-flexbox-bugs/ */
+#root > .sgds-masthead {
+  flex-shrink: 0;
+}
+
 #root > .main {
-  flex: 0 1 auto;
+  flex: 1 0 auto;
 }
 /* END - Add custom component classes before your utilities */
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,9 @@
 module.exports = {
   theme: {
+    container: (theme) => ({
+      center: true,
+      padding: theme("spacing.4"),
+    }),
     textColor: theme => ({
       ...theme("colors"),
     }),


### PR DESCRIPTION
- rename `Header` to `Masthead`
- set container spacing via config instead
- cross browser sticky footer fix (replace min-height with height)

issue: https://github.com/Open-Attestation/verify.gov.sg/issues/50