### PR TITLE
fix: display print button on mobile

### DIFF
--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -26,7 +26,7 @@ export const ButtonIcon: FunctionComponent<ButtonHTMLAttributes<HTMLButtonElemen
 }) => {
   return (
     <InnerButtonIcon
-      className={`transition-colors duration-200 ease-out cursor-pointer font-bold p-2 rounded shadow-md border border-transparent text-primary hover:text-primary-dark bg-white hover:bg-gray-100 hidden md:inline-block ${className} ${
+      className={`transition-colors duration-200 ease-out cursor-pointer font-bold p-2 rounded shadow-md border border-transparent text-primary hover:text-primary-dark bg-white hover:bg-gray-100 inline-block ${className} ${
         disabled && "cursor-not-allowed"
       }`}
       type="submit"

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -53,7 +53,7 @@ export const Tabs: React.FunctionComponent<TabsProps> = ({
 }) => {
   return (
     <nav className="flex justify-between">
-      <ul className="flex flex-wrap bg-gray-100 p-0">
+      <ul className="flex bg-gray-100 p-0 mr-2 overflow-x-auto">
         {templates.map(({ id, label }) => (
           <li
             data-testid="tabs-item"


### PR DESCRIPTION
**Context**
Print button does not appear on mobile screens.

**Reason**
Allow users on mobile to perform "Print to PDF".

**Fixes**
- Always display print button
- Allow horizontal scroll of tabs on mobile

Demo: https://user-images.githubusercontent.com/37650399/117615332-293fe580-b19c-11eb-8542-447a61461cf7.mov

Printing tested on Android:
![printing on android](https://user-images.githubusercontent.com/37650399/117280083-d5c85180-ae94-11eb-9088-1a320f32160a.png)