### PR TITLE
feat: obtain key from anchor

### DIFF
--- a/integration/load-action-encrypted-certificate.spec.ts
+++ b/integration/load-action-encrypted-certificate.spec.ts
@@ -9,6 +9,26 @@ const StatusCheck = Selector("[data-testid='status-check']");
 
 const key = "c246183c5dacff3a90ab82024ba2361b4bd8f9ade0b443f7c2d0cc5eebe9c8ca";
 
+test("Load document from action should work when action is valid (key from anchor)", async (t) => {
+  const anchor = { key };
+  const action = {
+    type: "DOCUMENT",
+    payload: {
+      uri: `https://gist.githubusercontent.com/Nebulis/49b53678e9b445f826125e4ac4f6d7a0/raw/ff6b53474fa24534f4f8c3c4aa89d17ac82a6289/encrypted-oa-issuer`,
+      permittedAction: ["STORE"],
+      redirect: "https://verify.gov.sg/verify",
+    },
+  };
+  await t.navigateTo(
+    `http://localhost:3000/verify?q=${encodeURI(JSON.stringify(action))}#${encodeURI(JSON.stringify(anchor))}`
+  );
+  await validateIssuer("example.openattestation.com");
+  await t.expect(StatusCheck.withText("Document has not been tampered").exists).ok();
+  await t.expect(StatusCheck.withText("Document has been issued").exists).ok();
+  await t.expect(StatusCheck.withText("Document’s issuer has been identified").exists).ok();
+  await validateIframeText("John Doe");
+});
+
 test("Load document from action should work when action is valid", async (t) => {
   const action = {
     type: "DOCUMENT",
@@ -25,6 +45,25 @@ test("Load document from action should work when action is valid", async (t) => 
   await t.expect(StatusCheck.withText("Document has been issued").exists).ok();
   await t.expect(StatusCheck.withText("Document’s issuer has been identified").exists).ok();
   await validateIframeText("John Doe");
+});
+
+test("Load document from action should fail when key is invalid (key from anchor)", async (t) => {
+  const anchor = {
+    key: "2a237b35cb50544a2c9a4b4a629e7c547bd1ff4a0137489700891532001e83f6", // random key, must have correct length
+  };
+  const action = {
+    type: "DOCUMENT",
+    payload: {
+      uri: `https://gist.githubusercontent.com/Nebulis/49b53678e9b445f826125e4ac4f6d7a0/raw/ff6b53474fa24534f4f8c3c4aa89d17ac82a6289/encrypted-oa-issuer`,
+      permittedAction: ["STORE"],
+      redirect: "https://verify.gov.sg/verify",
+    },
+  };
+
+  await t.navigateTo(
+    `http://localhost:3000/verify?q=${encodeURI(JSON.stringify(action))}#${encodeURI(JSON.stringify(anchor))}`
+  );
+  await t.expect(AlertContainer.withText(`Error decrypting message`).exists).ok();
 });
 
 test("Load document from action should fail when key is invalid", async (t) => {

--- a/src/components/verify/verify-page.tsx
+++ b/src/components/verify/verify-page.tsx
@@ -23,7 +23,6 @@ const Issuer = styled.span`
 `;
 
 const wait = (time: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, time));
-const getAnchor = (url: string) => (url.split("#").length > 1 ? `${url.split("#").pop()}` : null);
 
 const CheckStatus: React.FunctionComponent<{
   status: Status;
@@ -69,8 +68,8 @@ export const VerifyPage: React.FunctionComponent = () => {
   const location = useLocation();
   // use layout effect to run this as soon as possible otherwise the dropzone might be displayed before disappearing
   useLayoutEffect(() => {
-    const anchorStr = getAnchor(window.document.URL) ?? "{}";
-    const anchor: Anchor = JSON.parse(decodeURIComponent(anchorStr));
+    const anchorStr = decodeURIComponent(window.location.hash.substr(1));
+    const anchor: Anchor = anchorStr === "" ? {} : JSON.parse(anchorStr);
     const run = async () => {
       try {
         if (location.search) {

--- a/src/components/verify/verify-page.tsx
+++ b/src/components/verify/verify-page.tsx
@@ -9,7 +9,7 @@ import { retrieveDocument } from "../../services/retrieve-document";
 import { CheckCircle, Loader } from "../shared/icons";
 import { Section, Separator } from "../shared/layout";
 import { NavigationBar } from "../shared/navigation-bar";
-import { Status } from "./../../types";
+import { Status, Anchor } from "./../../types";
 import { DocumentRenderer } from "./document-renderer";
 import { DropZone } from "./dropzone";
 
@@ -23,6 +23,7 @@ const Issuer = styled.span`
 `;
 
 const wait = (time: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, time));
+const getAnchor = (url: string) => (url.split("#").length > 1 ? `${url.split("#").pop()}` : null);
 
 const CheckStatus: React.FunctionComponent<{
   status: Status;
@@ -68,6 +69,8 @@ export const VerifyPage: React.FunctionComponent = () => {
   const location = useLocation();
   // use layout effect to run this as soon as possible otherwise the dropzone might be displayed before disappearing
   useLayoutEffect(() => {
+    const anchorStr = getAnchor(window.document.URL) ?? "{}";
+    const anchor: Anchor = JSON.parse(decodeURIComponent(anchorStr));
     const run = async () => {
       try {
         if (location.search) {
@@ -79,7 +82,7 @@ export const VerifyPage: React.FunctionComponent = () => {
 
           setLoadDocumentStatus(Status.PENDING);
           const WAIT = 2000;
-          const [wrappedDocument] = await Promise.all([retrieveDocument(action), wait(WAIT)]);
+          const [wrappedDocument] = await Promise.all([retrieveDocument(action, anchor), wait(WAIT)]);
           setLoadDocumentStatus(Status.RESOLVED);
           setRawDocument(wrappedDocument);
         }

--- a/src/services/retrieve-document.ts
+++ b/src/services/retrieve-document.ts
@@ -1,5 +1,6 @@
 import { decryptString } from "@govtechsg/oa-encryption";
 import { v2, WrappedDocument } from "@govtechsg/open-attestation";
+import { Anchor } from "../types";
 
 interface Action {
   type: string;
@@ -9,9 +10,13 @@ interface Action {
   };
 }
 
-export const retrieveDocument = async (action: Action): Promise<WrappedDocument<v2.OpenAttestationDocument>> => {
+export const retrieveDocument = async (
+  action: Action,
+  anchor: Anchor
+): Promise<WrappedDocument<v2.OpenAttestationDocument>> => {
   if (action.type === "DOCUMENT") {
-    const { uri = "", key } = action?.payload ?? {};
+    const { uri = "" } = action.payload ?? {};
+    const key = action.payload?.key ?? anchor.key;
     let certificate = await window.fetch(uri).then((response) => {
       if (response.status >= 400 && response.status < 600) {
         throw new Error(`Unable to load the certificate from ${uri}`);

--- a/src/services/retrieve-document.ts
+++ b/src/services/retrieve-document.ts
@@ -16,7 +16,7 @@ export const retrieveDocument = async (
 ): Promise<WrappedDocument<v2.OpenAttestationDocument>> => {
   if (action.type === "DOCUMENT") {
     const { uri = "" } = action.payload ?? {};
-    const key = action.payload?.key ?? anchor.key;
+    const key = anchor.key ?? action.payload?.key;
     let certificate = await window.fetch(uri).then((response) => {
       if (response.status >= 400 && response.status < 600) {
         throw new Error(`Unable to load the certificate from ${uri}`);

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -5,3 +5,8 @@ export enum Status {
   RESOLVED,
   REJECTED,
 }
+
+// embedding secrets in anchor
+export interface Anchor {
+  key?: string;
+}


### PR DESCRIPTION
In order to keep secrets on the client side, this PR adds the ability to obtain the `key` from the anchor in URLs.

Verify will attempt to extract the `key` in the following order:
1. Anchor: `Anchor.key`
2. Query params: `Action.payload.key`

For future extensibility, `Anchor` is an object that will be safely encoded and appended as a string in the URL:
```javascript
export interface Anchor {
  key?: string;
}
```
```text
# Decoded example
https://verify.gov.sg/verify?q={"query":"params"}#{"key":"secret"}

# Encoded example
https://verify.gov.sg/verify?q=%7B%22query%22%3A%22params%22%7D%23%7B%22key%22%3A%22secret%22%7D
```