### PR TITLE
fix: add word break for oa support email

### DIFF
--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -45,7 +45,7 @@ const Contactus: NextPage = () => {
                 href="mailto:OpenAttestation_Support@tech.gov.sg"
                 target="_blank"
                 rel="noreferrer"
-                className="text-blue-600 underline hover:text-blue-700"
+                className="text-blue-600 underline hover:text-blue-700 break-all"
               >
                 OpenAttestation_Support@tech.gov.sg
               </a>


### PR DESCRIPTION
**Issue**
In the mobile view the oa support email link extends outside the box. (due to it being too long)

**Solution**
add css word break to force it to wrap.