### PR TITLE
chore: fix relative path for images

### DIFF
--- a/components/verify/Dropzone.tsx
+++ b/components/verify/Dropzone.tsx
@@ -92,7 +92,7 @@ const Dropzone: React.FC<DropzoneProps> = ({ onDocumentDropped = () => {}, onDoc
       >
         <input {...getInputProps()} />
         <div className="flex flex-col items-center gap-5">
-          <img className="max-w-[200px]" src="images/upload-document.svg" alt="Upload document" />
+          <img className="max-w-[200px]" src="/images/upload-document.svg" alt="Upload document" />
           <Heading level="h2" className="text-xl">
             Drag and drop file here
           </Heading>


### PR DESCRIPTION
## Context

Without a `/` in the front, the relative path will be appended after the existing path in the URL. To illustrate:

```url
# Existing path:
https://www.verify.gov.sg/some/path

# Appended (wrong):
https://www.verify.gov.sg/some/path/images/logo.png

# Appended (correct):
https://www.verify.gov.sg/images/logo.png
```

## The Fix

`/images/logo.png` will always be appended after the root domain (which is the behaviour we need for images).