### PR TITLE
fix: hourly monitoring being blocked by t&c modal

### DIFF
--- a/monitoring/infura.spec.ts
+++ b/monitoring/infura.spec.ts
@@ -55,7 +55,8 @@ const openGithubIssue = async (requestCount: number) => {
 
 test("Status check should reflect error correctly", async (t) => {
   // temporarily set cookie to dismiss Sep 2022 modal
-  await t.setCookies({ merge_acked: new Date(Date.now() - 5 * 60 * 1000).valueOf().toString() }, "https://infura.io");
+  const fiveMinsAgo = new Date(Date.now() - 5 * 60 * 1000).valueOf().toString();
+  await t.setCookies({ merge_acked: fiveMinsAgo, terms_accepted: fiveMinsAgo }, "https://infura.io");
 
   // login
   await t.typeText(Selector("[data-testid='field_email']"), process.env.INFURA_EMAIL ?? "");


### PR DESCRIPTION
## What does this PR do?
Temporarily set cookie to dismiss T&Cs modal that is overlaid on the Infura login page so that hourly monitoring test can proceed

Similar to #128 

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/37650399/192982992-539e894b-5513-4676-a4d8-4040626fbddf.png">
