### PR TITLE
feat: add alert dialog for non-compatible browser printing

### DIFF
--- a/components/figure/Renderer.tsx
+++ b/components/figure/Renderer.tsx
@@ -51,6 +51,15 @@ const Renderer: React.FC<RendererProps> = ({ document, rawDocument }) => {
   }, []);
 
   const handlePrint = useCallback(() => {
+    if (
+      navigator.userAgent.includes("SamsungBrowser") ||
+      navigator.userAgent.includes("CriOS") ||
+      navigator.userAgent.includes("FxiOS")
+    ) {
+      alert(
+        "Printing this document is not optimised on your device.\nFor the best result, use: \n- Chrome on Android devices \n- Safari on IOS devices \n- Any major browsers on desktop"
+      );
+    }
     toFrame && toFrame(print());
   }, [toFrame]);
 


### PR DESCRIPTION
## What this PR does:
- Checks for incompatible browsers and if user is printing from those browsers, prompt an alert box to let them know of the recommended browsers to use. Thereafter, print preview should show as per-normal (alert isn't a blocker)
- Referenced to the links below to check for Browser's User-Agent 
  - SamsungBrowser (`SamsungBrowser`) - https://developers.whatismybrowser.com/useragents/explore/software_name/samsung-browser/
  - iOS Chrome (`CriOS`) - https://www.whatismybrowser.com/guides/the-latest-user-agent/chrome
  - iOS FireFox (`FxiOS` - https://www.whatismybrowser.com/guides/the-latest-user-agent/firefox