### PR TITLE
test: fix hourly monitoring

### DIFF
--- a/monitoring/infura.spec.ts
+++ b/monitoring/infura.spec.ts
@@ -19,7 +19,8 @@ const statsLogger = RequestLogger(
     logResponseBody: true,
   }
 );
-fixture("Infura Monitoring").page`https://infura.io/login`;
+
+fixture("Infura Monitoring").page`https://infura.io/login`.requestHooks(statsLogger);
 
 const sleep = (timeout: number) => new Promise((resolve) => setTimeout(resolve, timeout));
 
@@ -67,7 +68,7 @@ test("Status check should reflect error correctly", async (t) => {
   await Selector("[data-testid='create-project']").with({ visibilityCheck: true })();
 
   // go to verify.gov.sg project
-  await t.click(Selector("p").withText("verify.gov.sg")).addRequestHooks(statsLogger);
+  await t.click(Selector("p").withText("verify.gov.sg"));
 
   const requestCount = await getRequestCount(statsLogger);
   const maximumRequest = 1000000;

--- a/monitoring/infura.spec.ts
+++ b/monitoring/infura.spec.ts
@@ -39,7 +39,7 @@ const getRequestCount = async (requestLogger: RequestLogger) => {
     }
     await sleep(1000);
   }
-  throw new Error("Could not find the stats");
+  throw new Error(`Could not find the stats: ${JSON.stringify(requestLogger.requests)}`);
 };
 
 const openGithubIssue = async (requestCount: number) => {


### PR DESCRIPTION
## Context
Hourly monitoring has been failing with `Could not find the stats` (i.e. `statsLogger` does not seem to be intercepting any HTTP requests)

## What does this PR do?
- a12d68d06dcb35da94398d5f50fd98dc61c7ebf9 For debugging purposes, print out all the requests that have been captured when error is thrown (this helped to identify the above finding as an empty array `[]` was printed)
- 308518a0f6ba1860c7f8c94caf0702438f6d61cc Attach `statsLogger` to the fixture instead. For some reason, it does not capture HTTP requests when attached to test controller even though it is [a documented way](https://testcafe.io/documentation/402842/guides/advanced-guides/intercept-http-requests#attach-hooks-to-tests-and-fixtures)