### PR TITLE
chore: disable monitoring

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,16 +6,16 @@ workflows:
   commit:
     jobs:
       - build
-  monitoring_hourly:
-    triggers:
-      - schedule:
-          cron: "0 * * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - monitoring
+  # monitoring_hourly:
+  #   triggers:
+  #     - schedule:
+  #         cron: "0 * * * *"
+  #         filters:
+  #           branches:
+  #             only:
+  #               - master
+  #   jobs:
+  #     - monitoring
 jobs:
   monitoring:
     docker:


### PR DESCRIPTION
due to circleci leak