### PR TITLE
feat: 183590615 stricter isRevoked checks

### DIFF
--- a/components/verify/Verifier.tsx
+++ b/components/verify/Verifier.tsx
@@ -105,7 +105,9 @@ const Verifier: React.FC<VerifierProps> = ({ wrappedDocument }) => {
       )}
 
       <VerificationChecks {...fragmentVerificationStatus} customMessage={customMessage} />
-      {verificationStatus === "VERIFIED" && <Renderer document={getDataV2OrV3(wrappedDocument)} rawDocument={wrappedDocument}/>}
+      {verificationStatus === "VERIFIED" && (
+        <Renderer document={getDataV2OrV3(wrappedDocument)} rawDocument={wrappedDocument} />
+      )}
     </section>
   );
 };

--- a/utils/fixtures/pdt_v2_healthcert_ocsp_revoked.json
+++ b/utils/fixtures/pdt_v2_healthcert_ocsp_revoked.json
@@ -1,0 +1,361 @@
+{
+  "version": "https://schema.openattestation.com/2.0/schema.json",
+  "data": {
+    "id": "5fa9e369-2d2e-461d-a897-b11e4b0eed29:string:ee72c7b2-9223-459f-8512-ee83340b4a18",
+    "version": "57fcc0b8-8329-49ac-a25b-0502efb4e36f:string:pdt-healthcert-v2.0",
+    "type": "7536df96-60fa-47d7-952b-214fd9616575:string:PCR",
+    "validFrom": "0acc4180-6cb2-4193-81a5-1f1859d34886:string:2021-08-24T04:22:36.062Z",
+    "fhirVersion": "5c6268a8-9237-4ef9-88ed-d0321a14ddc3:string:4.0.1",
+    "fhirBundle": {
+      "resourceType": "549122e0-fd9b-419f-96cf-99213aa55da3:string:Bundle",
+      "type": "2b9ac061-47d3-44c2-950f-809ac29a54ae:string:collection",
+      "entry": [
+        {
+          "fullUrl": "356b9f5d-c0e7-4d50-9d76-37659ef83f9d:string:urn:uuid:ba7b7c8d-c509-4d9d-be4e-f99b6de29e23",
+          "resource": {
+            "resourceType": "8b712e9a-b466-4a74-9fd0-c37306c2b89f:string:Patient",
+            "extension": [
+              {
+                "url": "42907e14-4ef3-4856-bb98-e85cd9cc8cf5:string:http://hl7.org/fhir/StructureDefinition/patient-nationality",
+                "extension": [
+                  {
+                    "url": "a0b6bad5-63bd-4a3c-b050-f1334be54edd:string:code",
+                    "valueCodeableConcept": {
+                      "text": "52dbe5fb-d564-4c4c-8a66-cbf97fa9ba1d:string:Patient Nationality",
+                      "coding": [
+                        {
+                          "system": "b9e91d31-85de-4cef-9657-1d7fe5125f20:string:urn:iso:std:iso:3166",
+                          "code": "23ebb468-ee5f-462d-9418-8a285587a141:string:SG"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "identifier": [
+              {
+                "id": "14ca0475-b6e6-44f5-abdc-118f149869b0:string:PPN",
+                "type": {
+                  "coding": [
+                    {
+                      "system": "b680014f-6dc2-419b-8019-72991d9a4350:string:http://terminology.hl7.org/CodeSystem/v2-0203",
+                      "code": "cf318485-bacd-460f-bc6e-166395080f1a:string:PPN",
+                      "display": "5dcbb19f-2ea2-4fde-8eed-4b52b63fe64b:string:Passport Number"
+                    }
+                  ]
+                },
+                "value": "ac8b977c-ed15-4e37-95c4-10ba76d2d1b4:string:E7831177G"
+              },
+              {
+                "id": "1456adc9-de23-4429-91d0-bc07e668f110:string:NRIC-FIN",
+                "value": "f5ee3efe-5b05-4a3b-b761-87de57b71347:string:S****470G"
+              }
+            ],
+            "name": [
+              {
+                "text": "af192e15-829d-4793-9e38-6689fd4fe511:string:Tan Chen Chen"
+              }
+            ],
+            "gender": "0da5b169-f926-4ec5-9aff-afc0472b798f:string:female",
+            "birthDate": "6f73a72b-5d9f-4ca3-8afd-44d55ce0b7c1:string:1990-01-15"
+          }
+        },
+        {
+          "fullUrl": "e08d7801-7d70-46d3-8c61-f13a9e354f59:string:urn:uuid:7729970e-ab26-469f-b3e5-36a42ec24146",
+          "resource": {
+            "resourceType": "fdb37349-a5ac-407f-ad62-ce1e8a8413ad:string:Observation",
+            "specimen": {
+              "type": "fbc00f24-aa80-4e88-b2de-dc62b9074b5f:string:Specimen",
+              "reference": "cd9ed2ec-b45c-400d-b5f9-06b541acfb2b:string:urn:uuid:0275bfaf-48fb-44e0-80cd-9c504f80e6ae"
+            },
+            "performer": [
+              {
+                "type": "26214f91-f7f9-4b77-977d-a7fe996be013:string:Practitioner",
+                "reference": "29e873c5-d00a-4f85-86d6-70e0279b94fe:string:urn:uuid:3dbff0de-d4a4-4e1d-98bf-af7428b8a04b"
+              },
+              {
+                "id": "9cdab09a-1f74-430d-9d4a-685b028b637f:string:LHP",
+                "type": "76d75431-e377-4b24-b515-b81787004f0b:string:Organization",
+                "reference": "5e629113-6a48-46d1-b342-e3ac48b0066f:string:urn:uuid:fa2328af-4882-4eaa-8c28-66dab46950f1"
+              },
+              {
+                "id": "a348ba43-0dde-442b-ac67-a74230d569e4:string:AL",
+                "type": "54c4a8cd-073d-417e-92cc-9fa60bfc26a5:string:Organization",
+                "reference": "e4bb84df-4639-4960-88cb-5619826f498c:string:urn:uuid:839a7c54-6b40-41cb-b10d-9295d7e75f77"
+              }
+            ],
+            "identifier": [
+              {
+                "id": "befdef53-ad0d-4ba3-a350-2b5d056828b0:string:ACSN",
+                "type": {
+                  "coding": [
+                    {
+                      "system": "f2e0d7e4-2900-44a0-82a3-a969a02dafe5:string:http://terminology.hl7.org/CodeSystem/v2-0203",
+                      "code": "a743ee13-4fcd-4ac3-b575-71ac71e3cf82:string:ACSN",
+                      "display": "6d6eb12e-230e-4946-ab3a-9fa7c2483083:string:Accession ID"
+                    }
+                  ]
+                },
+                "value": "c670b5c5-27d1-4ff8-b4d6-66eb185b5b0d:string:123456789"
+              }
+            ],
+            "category": [
+              {
+                "coding": [
+                  {
+                    "system": "c9537ae8-9319-4792-a5c2-9acd83bc4a51:string:http://snomed.info/sct",
+                    "code": "0a9bb0ea-e78c-4678-aa45-e1e67de1d107:string:840539006",
+                    "display": "810fc468-4c3f-410c-9176-f21fe8c24ff2:string:COVID-19"
+                  }
+                ]
+              }
+            ],
+            "code": {
+              "coding": [
+                {
+                  "system": "f4b2a001-bc5b-4139-b26b-47585113f113:string:http://loinc.org",
+                  "code": "9413183d-96a4-4cd1-b3d2-75ef09a51e04:string:94531-1",
+                  "display": "fb91dfaf-6d7e-4839-bd4a-b041f396d95f:string:SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "a3fb75e4-847f-40f8-9cff-5bfda3666483:string:http://snomed.info/sct",
+                  "code": "ec275ac9-5484-44fe-b25b-127dd7e9e571:string:260385009",
+                  "display": "0147b057-c77c-46b1-bb93-ad6672017a63:string:Negative"
+                }
+              ]
+            },
+            "effectiveDateTime": "b869efe9-4d32-47e3-9890-7afe03583bf7:string:2020-09-28T06:15:00Z",
+            "status": "38649648-7d4b-4314-81de-87dd1964b582:string:final"
+          }
+        },
+        {
+          "fullUrl": "4a0b90d1-22cb-4048-9d91-01acee5b693b:string:urn:uuid:0275bfaf-48fb-44e0-80cd-9c504f80e6ae",
+          "resource": {
+            "resourceType": "2c525e81-b952-4aec-8a79-5a1924e567d3:string:Specimen",
+            "type": {
+              "coding": [
+                {
+                  "system": "4018538a-97cc-4b02-b296-1e248f791460:string:http://snomed.info/sct",
+                  "code": "d099d7e9-550a-42e3-8ed2-95efe2ab2009:string:258500001",
+                  "display": "f355ae8c-001c-479d-a5b1-d35bc32cf91a:string:Nasopharyngeal swab"
+                }
+              ]
+            },
+            "collection": {
+              "collectedDateTime": "de42e34f-d15a-47ab-bf0e-1c8953604d5f:string:2020-09-27T06:15:00Z"
+            }
+          }
+        },
+        {
+          "fullUrl": "c6122f44-b7ba-487c-a1cd-42c7134f1537:string:urn:uuid:3dbff0de-d4a4-4e1d-98bf-af7428b8a04b",
+          "resource": {
+            "resourceType": "2f005618-7680-479f-b5e9-c20b5fd4bea1:string:Practitioner",
+            "name": [
+              {
+                "text": "71db4499-651e-49e0-8351-8b6972d60a3e:string:Dr Michael Lim"
+              }
+            ],
+            "qualification": [
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "e2216ca4-db50-4cb4-b2c0-0493e59c04ac:string:http://terminology.hl7.org/CodeSystem/v2-0203",
+                      "code": "c18b01e0-e94e-4096-867b-1360aac76955:string:MCR",
+                      "display": "3cf84f33-ed5a-41d2-aa44-c09f777881f6:string:Practitioner Medicare number"
+                    }
+                  ]
+                },
+                "identifier": [
+                  {
+                    "id": "3323e1fe-0af8-47bc-a5f9-5118f1387a43:string:MCR",
+                    "value": "8d42e624-6021-4a01-93cb-3753822c4b50:string:123456"
+                  }
+                ],
+                "issuer": {
+                  "type": "095369cb-cf31-421a-9d14-0a5c7f14d5ad:string:Organization",
+                  "reference": "9376a323-15d9-498c-8643-a3c4f4b1363b:string:urn:uuid:bc7065ee-42aa-473a-a614-afd8a7b30b1e"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "fullUrl": "35ba9a71-8b3e-4c64-834a-2bd1de3056a6:string:urn:uuid:bc7065ee-42aa-473a-a614-afd8a7b30b1e",
+          "resource": {
+            "resourceType": "9664b32d-c165-467e-89f7-df295ff628ba:string:Organization",
+            "name": "1af6e797-d3e9-44f0-bf4d-600f8dc28954:string:Ministry of Health (MOH)",
+            "type": [
+              {
+                "coding": [
+                  {
+                    "system": "494e9e0a-6244-427b-885f-e3f72f118703:string:http://terminology.hl7.org/CodeSystem/organization-type",
+                    "code": "460b0df6-4a15-433b-814c-1d3771699639:string:govt",
+                    "display": "eba9e590-4706-4c0f-9f66-d6ec8ed30744:string:Government"
+                  }
+                ]
+              }
+            ],
+            "contact": [
+              {
+                "telecom": [
+                  {
+                    "system": "9cb3ad27-7803-4de2-ad81-bb133df1eab1:string:url",
+                    "value": "b4503afd-9a5a-40c3-a95e-1cd37185684f:string:https://www.moh.gov.sg"
+                  },
+                  {
+                    "system": "97644114-af26-49c5-88f9-5180341c09ea:string:phone",
+                    "value": "47b1df7b-c6e0-49f5-8a51-7e2d7cf09fdd:string:+6563259220"
+                  }
+                ],
+                "address": {
+                  "type": "c62d5643-1f0e-4a31-bdb0-88f9ee266381:string:physical",
+                  "use": "e458dfea-09a5-433e-9612-3e320c0fcea7:string:work",
+                  "text": "ab9ec01b-5add-4e29-b00e-8746b998494b:string:Ministry of Health, 16 College Road, College of Medicine Building, Singapore 169854"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "fullUrl": "cd1527e3-eda7-4517-a2d8-95cfbf932ca0:string:urn:uuid:fa2328af-4882-4eaa-8c28-66dab46950f1",
+          "resource": {
+            "resourceType": "e5947910-20d8-4d00-a1ad-6cf57e402859:string:Organization",
+            "name": "8e49138d-ae63-4d5c-8a50-f653f0fec4ee:string:MacRitchie Medical Clinic",
+            "type": [
+              {
+                "coding": [
+                  {
+                    "system": "c3ae6d15-521a-4604-92b5-bb25af0467ba:string:http://terminology.hl7.org/CodeSystem/organization-type",
+                    "code": "b4e42682-4c96-4137-8c3b-53e0a99e3692:string:prov",
+                    "display": "3f5fb0c9-c7ee-4467-84f5-9228cc192beb:string:Healthcare Provider"
+                  }
+                ],
+                "text": "acd86f38-2241-49d7-b77c-4e39a461d0d8:string:Licensed Healthcare Provider"
+              }
+            ],
+            "contact": [
+              {
+                "telecom": [
+                  {
+                    "system": "ca801686-c27f-4927-832c-f2e989e1bf0f:string:url",
+                    "value": "8f39d6e5-bf93-40b4-bbea-ce910906152c:string:https://www.macritchieclinic.com.sg"
+                  },
+                  {
+                    "system": "c23e12f4-a729-49d7-a0a2-db8f2a26efe8:string:phone",
+                    "value": "9c3533b2-87ba-4ac7-8ecc-dae3a984dc47:string:+6561234567"
+                  }
+                ],
+                "address": {
+                  "type": "0b23a40f-8631-469b-a002-991acd6bc2a1:string:physical",
+                  "use": "2af2338c-e2a2-44cb-a1a1-1d49cb20d80b:string:work",
+                  "text": "640688f9-1d35-4098-8841-986e614fbceb:string:MacRitchie Hospital, Thomson Road, Singapore 123000"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "fullUrl": "13b25969-a2a3-4a62-b037-3df00b7b7471:string:urn:uuid:839a7c54-6b40-41cb-b10d-9295d7e75f77",
+          "resource": {
+            "resourceType": "6176895a-f5ee-47df-804e-50806bbe6ce5:string:Organization",
+            "name": "00bfafb6-df43-4f3c-bd07-4a09f987679b:string:MacRitchie Laboratory",
+            "type": [
+              {
+                "coding": [
+                  {
+                    "system": "7aa77f92-c7e2-40b1-822a-a7227bcbca46:string:http://terminology.hl7.org/CodeSystem/organization-type",
+                    "code": "68dfe938-adbf-4e88-be3d-68581e86e890:string:prov",
+                    "display": "2ee4eaa1-0458-4423-b8d6-cd8f6e04216d:string:Healthcare Provider"
+                  }
+                ],
+                "text": "e74c8b59-b96f-4b7a-ac30-8cb90b07c101:string:Accredited Laboratory"
+              }
+            ],
+            "contact": [
+              {
+                "telecom": [
+                  {
+                    "system": "f8eb2b93-9698-43e3-9830-695e01bec84c:string:url",
+                    "value": "94eacd1f-ffa1-4c7a-9f7a-335f5d541a48:string:https://www.macritchielaboratory.com.sg"
+                  },
+                  {
+                    "system": "a42869a5-8abe-4975-b4a9-044df081904a:string:phone",
+                    "value": "f40fe34e-35bf-467c-9a55-bdac6e1ed133:string:+6567654321"
+                  }
+                ],
+                "address": {
+                  "type": "765b873d-1621-43bd-870e-d6c89b2782bf:string:physical",
+                  "use": "f606ce1e-e142-41f7-a81a-0de640d47d73:string:work",
+                  "text": "0098643f-f641-4b2d-9d8c-e5614e4be6d7:string:2 Thomson Avenue 4, Singapore 098888"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "issuers": [
+      {
+        "name": "fb00e458-a814-449a-9138-45531d3854a0:string:SAMPLE ISSUER (DO NOT VERIFY)",
+        "id": "b1080249-646b-4edb-9456-8da6a7caceb6:string:did:ethr:0xE39479928Cc4EfFE50774488780B9f616bd4B830",
+        "revocation": {
+          "type": "2d6d513c-1b74-4c4e-bde3-4f01fb93bb09:string:OCSP_RESPONDER",
+          "location": "9a40a8ca-9105-402c-8ed2-f1ae69a2cd53:string:https://ocsp-responder.aws.notarise.gov.sg"
+        },
+        "identityProof": {
+          "type": "561d4607-3e6d-4c34-a2bc-9662c46f8ed0:string:DNS-DID",
+          "location": "8553a006-55a8-4fb8-80bf-ee5bfb862675:string:donotverify.testing.verify.gov.sg",
+          "key": "d388e554-6fd2-487f-8895-30e1f995f9bf:string:did:ethr:0xE39479928Cc4EfFE50774488780B9f616bd4B830#controller"
+        }
+      }
+    ],
+    "$template": {
+      "name": "08264bd1-706d-4b32-bbc1-3e0a8a0e6f36:string:HEALTH_CERT",
+      "type": "901abb01-a601-40b2-8225-bbd4186ee519:string:EMBEDDED_RENDERER",
+      "url": "0fd1808e-e0b8-4da4-96c2-118b5c730677:string:https://healthcert.renderer.moh.gov.sg/"
+    },
+    "notarisationMetadata": {
+      "reference": "fc039f0e-47ea-4ee1-a4bf-6169a8aed063:string:ee72c7b2-9223-459f-8512-ee83340b4a18",
+      "notarisedOn": "a73cf120-d058-4d6f-a55b-74c4d4829d5f:string:2022-06-22T03:31:16.929Z",
+      "passportNumber": "7374a64e-4ba1-424d-ab51-5b41b5934109:string:E7831177G",
+      "url": "40533a2e-25f9-48f3-a189-643bd83aa7c0:string:https://dev.verify.gov.sg/verify?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi.storage.staging.notarise.io%2Fdocument%2Fef5ea41c-7e60-43a3-bd23-931df6aee1e0%22%7D%7D#%7B%22key%22%3A%2230bb81b4ca1a505b1dec3ff130dba7f72f23a24898e1417dc214266d7cf8b9c4%22%7D",
+      "signedEuHealthCerts": [
+        {
+          "type": "17eb4be5-d043-4321-814d-022a6daee8ba:string:PCR",
+          "expiryDateTime": "79b34b97-765c-4150-a681-e478bc156f08:string:2022-06-29T03:31:16.867Z",
+          "qr": "6238009f-d373-4c0c-acc1-3f35d04f3e53:string:HC1:6BFGY8VAQGP2IQ2N.E9%3-01-412%GXHGJ5U8QLBQL.QNSUNOWE*5N5-0GP6Z+PLTS 42-PL-1DM4Q:AN-:M T9EH9CNHYPGXD8/YPUCI9H87NCF00*H4URS*8I+CK+PBC9F1VNKO2%DU*I5%QFE2R45OY9K/N7VQI5R9P9T5UO$19D9L23M914GX7+D5OSN30PM%KC%VF1UV7DOUVDQUSQP9KE:.SXQB%%GATO:VRJ+9J8OP%D*0MI$GM05LXALBH .3UVG+:E02OGWF3ATC.57G20Z06YI/R8FD8K2AWW1 ZS%FQ.56UI942NKII1R3GBRH-Q+SBDG54*4U1END4.D43H2IC88BC740L3J6RMVE9NQHAO97ZQ$$T*.I+BIR-6KWHWSPXZN/ LBQR6$4HOG4LR3$DX1T. E6%M%NT6 AO2D19LWCRDV9GIN0K8-46/$CJQM9.KA6EL:AKFCI$UCOGNJ98NUL26INQLMG*1H9VBNNLG585591L9KJJ7F1S7TDWL.GP6K7UMB+6G0RQVBB9-K9WMBE2D0LX-E07L7J8LSB:KL:ZD6OKLC5Y+H+IR6I90%GAIS9QV01I5EKJLL8:4 I37MSRA8:BP.C8MFO9NIMQ36K3ONG.CJNEJBYJ4DQLR2BBJWMI1I9307-J6:VG$MTJ%6W07O:27TLVKHKWRBDP 3PFUBRGEIM9JW2-U6T6W:*6P69./0E80EE0. 5TSIKQSWKH6YGR56:AE74QCM91LN9X2ITLRQ94L0Q0KKYMKF6O/S0VEWJV-$BR7M 41VMEZ+NT4N%+UBJ2XLJXBMW3NR03+3D5 Q:RN5ID8ULZ:M050JEKN63D56H$K$4T2ULLFCI:I5S7LUPG-LA0AQ3W6K9ORRFVOCNNQ9121MKBR*9TY6V+78-AA:839SAW881IA-1L0/BAK6A 80YKEBBVHCTH31I5LKKQ%0QSU-25*B5S$KR8J%E7XBUB2OIFW5PP8-F.MRW9MUQF0WU8:3U4LQ05+0G:7G.TSN8NUYV67WF9OWEU238D39CXO WLJZV/9WQWP2LO34WFP7D15H*2*LV117.E1",
+          "appleCovidCardUrl": "39b6ae7a-7ca2-458c-89e3-1641c4b4d2c3:string:https://redirect.health.apple.com/EU-DCC/#6BFGY8VAQGP2IQ2N.E9%253-01-412%25GXHGJ5U8QLBQL.QNSUNOWE*5N5-0GP6Z%2BPLTS%2042-PL-1DM4Q%3AAN-%3AM%20T9EH9CNHYPGXD8%2FYPUCI9H87NCF00*H4URS*8I%2BCK%2BPBC9F1VNKO2%25DU*I5%25QFE2R45OY9K%2FN7VQI5R9P9T5UO%2419D9L23M914GX7%2BD5OSN30PM%25KC%25VF1UV7DOUVDQUSQP9KE%3A.SXQB%25%25GATO%3AVRJ%2B9J8OP%25D*0MI%24GM05LXALBH%20.3UVG%2B%3AE02OGWF3ATC.57G20Z06YI%2FR8FD8K2AWW1%20ZS%25FQ.56UI942NKII1R3GBRH-Q%2BSBDG54*4U1END4.D43H2IC88BC740L3J6RMVE9NQHAO97ZQ%24%24T*.I%2BBIR-6KWHWSPXZN%2F%20LBQR6%244HOG4LR3%24DX1T.%20E6%25M%25NT6%20AO2D19LWCRDV9GIN0K8-46%2F%24CJQM9.KA6EL%3AAKFCI%24UCOGNJ98NUL26INQLMG*1H9VBNNLG585591L9KJJ7F1S7TDWL.GP6K7UMB%2B6G0RQVBB9-K9WMBE2D0LX-E07L7J8LSB%3AKL%3AZD6OKLC5Y%2BH%2BIR6I90%25GAIS9QV01I5EKJLL8%3A4%20I37MSRA8%3ABP.C8MFO9NIMQ36K3ONG.CJNEJBYJ4DQLR2BBJWMI1I9307-J6%3AVG%24MTJ%256W07O%3A27TLVKHKWRBDP%203PFUBRGEIM9JW2-U6T6W%3A*6P69.%2F0E80EE0.%205TSIKQSWKH6YGR56%3AAE74QCM91LN9X2ITLRQ94L0Q0KKYMKF6O%2FS0VEWJV-%24BR7M%2041VMEZ%2BNT4N%25%2BUBJ2XLJXBMW3NR03%2B3D5%20Q%3ARN5ID8ULZ%3AM050JEKN63D56H%24K%244T2ULLFCI%3AI5S7LUPG-LA0AQ3W6K9ORRFVOCNNQ9121MKBR*9TY6V%2B78-AA%3A839SAW881IA-1L0%2FBAK6A%2080YKEBBVHCTH31I5LKKQ%250QSU-25*B5S%24KR8J%25E7XBUB2OIFW5PP8-F.MRW9MUQF0WU8%3A3U4LQ05%2B0G%3A7G.TSN8NUYV67WF9OWEU238D39CXO%20WLJZV%2F9WQWP2LO34WFP7D15H*2*LV117.E1"
+        }
+      ]
+    },
+    "logo": "b0a74a7f-17db-462e-a291-65ecb257bf28:string:data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAfQAAADICAMAAAApx+PaAAAAM1BMVEUAAADMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzeCmiAAAAAEHRSTlMAQL+A7xAgn2DP3zBwr1CPEl+I/QAABwdJREFUeNrsnd122yoQRvkHISHN+z/tyUk9oTECQ1bTBc23byNs0B5GIDARAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAk+Ik+Idx4g5N4B9GQ/rPA9J/IPfSgwL/MEEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwP5ZPoP5r7FJKAf7cufBihPNSkX5hlA9u+DsP7dX/JK1P2VPiSIoebErLwVh5Zx+8C1Y22YtP0Fpf6hdea+mq1Wlixfej6RcDxj09swXbbeBQpijug20aj/SE8bvo5hEuavAuSKpQfJxTG91gUrCV6jSQE0oPke4wuke705EqpLNWxtMtSk4jvXGld+tLlxvVMNnakD7mEndYTVWSnV860WUXl34RMy7BempyGzN7pAbmXEA6bfvK0u32uTFKKVM0r0Yw1MTcFvp8iVLPD0+9gHQy+7rSf3eejp2HuFcsmldiEz0FzKXfSRw3qe08Xqd9dP6QKONnku4lG3NSb/RBtKtKt1ttdBJiYb2VI7brc7tc8IYotJzHUB0c+O+T3rTQuLKsZRqpzkTS7dZI4vo+qJndEGO8Ezecyjac6/ITN2KOWaULIT/aLdeUnqpdi7VW2+Kyc29FL3s7e3hi5LTSheWWpyWlH4XzmvWjniOiFN3YWDivWI92Wuk5ct2C0p3Jzl9YN66WI5IV/VyF86r1a17pH5UMC0pX/DwXVU524Ks5YgDZmL4zGz1w80p33Pj1pMvci+tc2cFIjmhH2dWVfuaVLuLjy9eTzgqOrqewv0vum/1KR4+2a6Dh5pXO7V9O+s4KRJPADuxNjtjFCCk/CltEzgfzSterSvdZQZeDoyyqxQguR1lXmBlI/9PSebZpbOe8bivt2bFK9YaK4eHe7NLNatLP3qGYLfL71RoMvB6Xu96J3TWt9LToQM5zm8YfxbHIESPZXXW/tovTSo+PqFxNeswZqjO/X09OvBgi9OcHw7llUukcv+di0rneqf99uXoKglMMwall7x/my0mlP5piVnv3fuZ+193xnpTYLz3SjejPLXpO6TtXbzXpfIUceJHmPsXAJsbI+aL7fvsppVsOX7uadJ9FvuT63PxsZAQ3UMxygLyWvsk6/luku40fb8ttolDFFb1ZQQ6/mRkv1iW9i1J6C/1aejAcvQPVmUt6FB2cn26JzDO4TsaLcWeaTbo7In04X08696XxTnrkmzGCHimmJpLuNaPi71f+KOkte5IK9OrS74ingPSfJd1oISD9Z0m/hPhB0o+/Ld3MMGUrSU68s9yUzXSO3suhW+Bh+Jj0oyz2snZqgpczd5iwpvRvmKfXpY/P0yeSfsgHOhliwtLS7cBSiR1aZFP30q+Bt3fXbK9hQ2Tr+4rSc+8dflXCO2l6pY+PIs5pF1xs4kmbXVB6z0JWRRdH+6B0w8VeoydeWlV84xaULnvX08vEzNn+HJOu+tfT1cSbKPLewvWkc/c1/Yts4SlJ+DHpunsF3069XSrw7VhQel4gHN3QuHO8jEk/O8cC+Uo/pXR+vG0LSn/ZXxlXyIoc60PSheldwvdzb4HW3I71pO/0wHYqOIp8v41JT52TNjf5jx24fmE96WLrG7/bsoM6ehCGpJ8s0/ZV3k8qnTOdX1B66HOgb4b5KRftl54fC7ovyvZZpXt6Jy4o3ZqedOvMTdslPUhD0rlWxvVMFtS0P1UOnPvWk84Xdb0DIXW/kHiMSLem7rMMKDmt9J0HmgtK/3Bg7GhgOGLCgPT8afp1pdTEx4886ngtKF2c9OpsgVDbOKCJOQaki+1VrFi+wriJpfNa/orShcrW286jLYsyyfZLl8SEtnM65j1SLH+wXVG6jc0DYI986FujKJnQLV0c1Mrw7sO5n/fwwDfkoj9gfD4ozhyFAUVMqBRlYrCd0oUnRrkiyEzOPFNLFzTzT5VlBXd3Om8ozkBtOOdDPZkU9k9/PCpLkHarnZUfIhXOv0/6ISv0SOcvj/1b9tzfkN5G3x7ebdIh34WfF6tpDrrYK6PUpd/4fJS3bpXartOJN+SRDBXOv0l6m6EzZ1z35lw9k3RO01WMFBU4H4+21lMbb8Xs0vlvYVHp3PUqKCcaODUsnbNLSR5cTC+dZ+ppVelCnKa117eNTNQkSVFiU2tP+QrSOVvZZaULqwvtPCh/jdMb3RN99QOkojv8LsQS0k/O7+tKf+NMT96NP0UvLvinRm9Jn24wVrbDCbGIdF4xVBNJ/xJSe6Ueo/Bj/9I/7Dy0PvrnJy5opSIRRZX0aQUAAPzX3h3UAACAQAx7YAD/anFBCNdamIABAAAAAAAAAAAAAAAAAAAAAAAAAADAmmoeK9HziB5I9EBXnx8AAAAAAAAAALBmAIZKmzWInxyOAAAAAElFTkSuQmCC",
+    "attachments": [
+      {
+        "filename": "01afad9b-05e0-4566-bd08-43ca909a19a4:string:healthcert.txt",
+        "type": "6af520d4-da39-4299-b263-24597d05f948:string:text/open-attestation",
+        "data": "45b8d7ca-66c5-4b0c-bbd8-bf98a2a51e95:string:eyJ2ZXJzaW9uIjoiaHR0cHM6Ly9zY2hlbWEub3BlbmF0dGVzdGF0aW9uLmNvbS8yLjAvc2NoZW1hLmpzb24iLCJkYXRhIjp7ImlkIjoiMmMwMWM2NjQtYTJmOS00ODQ3LTkxNTgtOGNlMzM3ZmUwZmUyOnN0cmluZzo3NmNhZjNmOS01NTkxLTRlZjEtYjc1Ni0xY2I0N2E3NmRlZGUiLCJ2ZXJzaW9uIjoiZjk5ZDBjZWQtODM5Ny00Y2Q0LTg1NTgtNjQ1Nzg4YjQ5NThjOnN0cmluZzpwZHQtaGVhbHRoY2VydC12Mi4wIiwidHlwZSI6IjA1ZTU3NTg1LTdjY2MtNGI2MS1iMjEyLTU4MjgyOGY2ZDYzMzpzdHJpbmc6UENSIiwidmFsaWRGcm9tIjoiOTBiZDYxYmItOGVmMi00M2M1LWFlZTItYzNiN2Y5NzJjNGEwOnN0cmluZzoyMDIxLTA4LTI0VDA0OjIyOjM2LjA2MloiLCJmaGlyVmVyc2lvbiI6IjllMWMwMjI5LTQ1NTAtNDhhMy04MWU5LWMwZDQ2YzZhN2VhZjpzdHJpbmc6NC4wLjEiLCJmaGlyQnVuZGxlIjp7InJlc291cmNlVHlwZSI6ImU2MmU2ZDc3LTM1OWQtNGY5Mi04NTliLTg0ZjFlMGZkYmFjYzpzdHJpbmc6QnVuZGxlIiwidHlwZSI6ImFhOWUwNThiLTQzNDQtNDJjMC05NTBjLWIyZjU1ZTFmMGQyMjpzdHJpbmc6Y29sbGVjdGlvbiIsImVudHJ5IjpbeyJmdWxsVXJsIjoiZmJlNDY2ZjktYzM4NC00NzcxLWJhODEtYjY5Njk4MGRmZmM0OnN0cmluZzp1cm46dXVpZDpiYTdiN2M4ZC1jNTA5LTRkOWQtYmU0ZS1mOTliNmRlMjllMjMiLCJyZXNvdXJjZSI6eyJyZXNvdXJjZVR5cGUiOiI1MmQ3MDc4NS0yNGU5LTQ5NzItYmFiYS0zNjY0ZTY3NDc4OTA6c3RyaW5nOlBhdGllbnQiLCJleHRlbnNpb24iOlt7InVybCI6ImVjNjM1Njc1LTE4M2ItNDdjOS05OWMxLWUzM2E4OTRlNjg1ODpzdHJpbmc6aHR0cDovL2hsNy5vcmcvZmhpci9TdHJ1Y3R1cmVEZWZpbml0aW9uL3BhdGllbnQtbmF0aW9uYWxpdHkiLCJleHRlbnNpb24iOlt7InVybCI6IjEwZGM4ZWNmLTI4YjktNGIxYi04YWYyLTA0YmZhOTlhMjNiMzpzdHJpbmc6Y29kZSIsInZhbHVlQ29kZWFibGVDb25jZXB0Ijp7InRleHQiOiI1OTRkMGI5MS1kYmE0LTRmNWQtODk4Ny1lYzdiNTExNzM3ZDA6c3RyaW5nOlBhdGllbnQgTmF0aW9uYWxpdHkiLCJjb2RpbmciOlt7InN5c3RlbSI6IjMzZTEzNmM3LTMzZDgtNDkyMi05N2FhLWIzNDQ0YzZmNjk2ZjpzdHJpbmc6dXJuOmlzbzpzdGQ6aXNvOjMxNjYiLCJjb2RlIjoiMTFkYzVmMzQtNDMzOS00NmUwLTg5N2UtYzU4NmFhZWI0OWYxOnN0cmluZzpTRyJ9XX19XX1dLCJpZGVudGlmaWVyIjpbeyJpZCI6Ijc1YjA0OTNmLThhMDQtNGNhOS04MzhiLTYxMzM5MDk2Y2IxNzpzdHJpbmc6UFBOIiwidHlwZSI6eyJjb2RpbmciOlt7InN5c3RlbSI6IjJiYmU3MWIzLTVhNWUtNDE1OC05MmRhLTA3ZDcwNWJlNzIyMzpzdHJpbmc6aHR0cDovL3Rlcm1pbm9sb2d5LmhsNy5vcmcvQ29kZVN5c3RlbS92Mi0wMjAzIiwiY29kZSI6IjBiNTBkNWM2LTEzNDEtNDg3YS1hNmEzLTk5MDRiMDA2NDcwOTpzdHJpbmc6UFBOIiwiZGlzcGxheSI6IjYxOThjYzllLWRhNTItNDBhOC1iN2JhLWRjY2YxZjA4ZmM3ZDpzdHJpbmc6UGFzc3BvcnQgTnVtYmVyIn1dfSwidmFsdWUiOiI3ODIzNTlmOC1jNDA5LTQyYmYtYTNiYS1kNDk1YTUxMjI1NTU6c3RyaW5nOkU3ODMxMTc3RyJ9LHsiaWQiOiJjODYyOTJlNy1jZDg2LTQ0OGMtYjQzYy1iOWE3OTRjYTVhOTg6c3RyaW5nOk5SSUMtRklOIiwidmFsdWUiOiIyODljOTkzZC0xNWMxLTRmZjItOWQzMi1mZTQwZmJjZWJkOWE6c3RyaW5nOlMzMDAxNDcwRyJ9XSwibmFtZSI6W3sidGV4dCI6Ijk3YjI5ZDJjLTYyZGQtNGIxOS1iOTMzLTkwNTUzMTZjMGZhODpzdHJpbmc6VGFuIENoZW4gQ2hlbiJ9XSwiZ2VuZGVyIjoiZmNhNzAzMzEtOTNhZi00ZmI4LWIyYzAtYTczNWEwZGMzYjJlOnN0cmluZzpmZW1hbGUiLCJiaXJ0aERhdGUiOiI4NGFjYTc2Mi1kOTk0LTQ2NDgtYThmNy03YzA5MjcyMGFjNTA6c3RyaW5nOjE5OTAtMDEtMTUifX0seyJmdWxsVXJsIjoiNDc2MjgyNTUtMjllYi00YmEyLThmY2UtNzc1MjNhYTM5OTc3OnN0cmluZzp1cm46dXVpZDo3NzI5OTcwZS1hYjI2LTQ2OWYtYjNlNS0zNmE0MmVjMjQxNDYiLCJyZXNvdXJjZSI6eyJyZXNvdXJjZVR5cGUiOiJmZWEzZmQwNi02ZTNiLTRiNzctYWZkMi1lMmY4ZTdiZjU3YmY6c3RyaW5nOk9ic2VydmF0aW9uIiwic3BlY2ltZW4iOnsidHlwZSI6Ijc4OGQ0YWRkLWFkYmYtNDViMS1iZGZjLWQ3OGU5M2Q4YjEyMzpzdHJpbmc6U3BlY2ltZW4iLCJyZWZlcmVuY2UiOiI2Y2Q5NTBmZi03OWNlLTQ5MzctODkwMC1mOTE1YjdhNjU1NTY6c3RyaW5nOnVybjp1dWlkOjAyNzViZmFmLTQ4ZmItNDRlMC04MGNkLTljNTA0ZjgwZTZhZSJ9LCJwZXJmb3JtZXIiOlt7InR5cGUiOiJjZGMzMGMxNC00NDE2LTRkZmItOTAxNi0yNDJhYWFjMTk3ZjE6c3RyaW5nOlByYWN0aXRpb25lciIsInJlZmVyZW5jZSI6IjczYWE1OTdiLTk5ZGItNDA3MS05MDA3LTQ1YjU1MTMxM2Y2YzpzdHJpbmc6dXJuOnV1aWQ6M2RiZmYwZGUtZDRhNC00ZTFkLTk4YmYtYWY3NDI4YjhhMDRiIn0seyJpZCI6Ijg3ZTQ0ZjlmLWI0ZTctNDEyZi05MzcwLTE3Y2VlMDUyNzU3ODpzdHJpbmc6TEhQIiwidHlwZSI6IjgyOWFjZWY0LTY2YWMtNGY5MC1hMTQxLTFjYzFiZTg2MWU1YjpzdHJpbmc6T3JnYW5pemF0aW9uIiwicmVmZXJlbmNlIjoiYjA2Njk5OTgtZWVhMC00N2M2LWE5Y2UtN2E5YjE2N2QyYjg4OnN0cmluZzp1cm46dXVpZDpmYTIzMjhhZi00ODgyLTRlYWEtOGMyOC02NmRhYjQ2OTUwZjEifSx7ImlkIjoiMzBjNTI3ZmQtZWNmZS00MWE1LThlMDEtNjc5YjliY2JjYzY5OnN0cmluZzpBTCIsInR5cGUiOiIyNjhmMDE0NC0zMWRlLTQzZTgtYTY5OC1kMjUwNDk2MjhiNDY6c3RyaW5nOk9yZ2FuaXphdGlvbiIsInJlZmVyZW5jZSI6ImY4ODhkYjMyLTdhODEtNDhhMy05MDU1LTY5ZTJmZTI2MGEyNjpzdHJpbmc6dXJuOnV1aWQ6ODM5YTdjNTQtNmI0MC00MWNiLWIxMGQtOTI5NWQ3ZTc1Zjc3In1dLCJpZGVudGlmaWVyIjpbeyJpZCI6IjcwNzE2MDE0LTZiOWYtNGZjZC1hM2RkLTc5NzI0YWEzMTM0MjpzdHJpbmc6QUNTTiIsInR5cGUiOnsiY29kaW5nIjpbeyJzeXN0ZW0iOiJiZmIyM2ZlZi01YzY3LTRiZjctOGFkMC0wMTUwNTE2NjEwMjM6c3RyaW5nOmh0dHA6Ly90ZXJtaW5vbG9neS5obDcub3JnL0NvZGVTeXN0ZW0vdjItMDIwMyIsImNvZGUiOiJhZTNkOTg5ZC0yMDg2LTQ5NzgtODY0Zi04MzI0ZmZhMjczMmM6c3RyaW5nOkFDU04iLCJkaXNwbGF5IjoiNGEzMTBjMmItOWY3MC00NDA3LWFhZDYtMzVlMzFkZDFjYTZiOnN0cmluZzpBY2Nlc3Npb24gSUQifV19LCJ2YWx1ZSI6IjNlMGY1M2M0LTJlOWQtNGE3OC05NDA5LTgxMDYzZTZkZjgxMzpzdHJpbmc6MTIzNDU2Nzg5In1dLCJjYXRlZ29yeSI6W3siY29kaW5nIjpbeyJzeXN0ZW0iOiJkMDg4OTI0MC1iNTg3LTRjN2MtYjE3NC00MDFmZGYzZWYyYWI6c3RyaW5nOmh0dHA6Ly9zbm9tZWQuaW5mby9zY3QiLCJjb2RlIjoiMDMyNGFhNzctM2MxMS00YTVhLWEyOTYtNWQzNmE4NzFiM2JmOnN0cmluZzo4NDA1MzkwMDYiLCJkaXNwbGF5IjoiYjBhYzIxNjItZDM4MC00YWZhLTgwZjAtZjc0MjQ2NDNkNDAyOnN0cmluZzpDT1ZJRC0xOSJ9XX1dLCJjb2RlIjp7ImNvZGluZyI6W3sic3lzdGVtIjoiMjA4ZjZiM2UtNzk3OC00YjhmLTkyZTQtMzJmYjAzN2U0OWJiOnN0cmluZzpodHRwOi8vbG9pbmMub3JnIiwiY29kZSI6ImM5MjRlZjUwLTAzMjUtNGI5Ny04YzdmLWI5MTMxYTU1MjkyYTpzdHJpbmc6OTQ1MzEtMSIsImRpc3BsYXkiOiJkYTMwZGViNi05NDg3LTQ5NjYtOTkwZC1jODVhMWUzZjZiZmM6c3RyaW5nOlNBUlMtQ29WLTIgKENPVklELTE5KSBSTkEgcGFuZWwgLSBSZXNwaXJhdG9yeSBzcGVjaW1lbiBieSBOQUEgd2l0aCBwcm9iZSBkZXRlY3Rpb24ifV19LCJ2YWx1ZUNvZGVhYmxlQ29uY2VwdCI6eyJjb2RpbmciOlt7InN5c3RlbSI6ImYxMTcxMzA0LTM5MmItNDMwNy1hNzBlLTVhZTk2MDJhN2RlZTpzdHJpbmc6aHR0cDovL3Nub21lZC5pbmZvL3NjdCIsImNvZGUiOiJhMThkMTNiNC00YWU1LTQ3YzMtODJmYy03ZjM5N2ZmZjFiODE6c3RyaW5nOjI2MDM4NTAwOSIsImRpc3BsYXkiOiI5MWE1NmVjOS1lMmE1LTQ2YTMtYTM0Yy05ZDViOTBmYmFmY2E6c3RyaW5nOk5lZ2F0aXZlIn1dfSwiZWZmZWN0aXZlRGF0ZVRpbWUiOiIxZDc3ZjMxMi03NTgxLTQ3ZDgtOTkyYy04Y2ViOGY5MzVhODQ6c3RyaW5nOjIwMjAtMDktMjhUMDY6MTU6MDBaIiwic3RhdHVzIjoiYmYzYWNjMjEtNGU1Yi00ODg5LTk1MzYtYTZiZGFiZjliNjAxOnN0cmluZzpmaW5hbCJ9fSx7ImZ1bGxVcmwiOiI1NzljZWRmYy1kNTQ5LTQ0N2ItOTdlNy03OTNhNGVmZDc1ZTA6c3RyaW5nOnVybjp1dWlkOjAyNzViZmFmLTQ4ZmItNDRlMC04MGNkLTljNTA0ZjgwZTZhZSIsInJlc291cmNlIjp7InJlc291cmNlVHlwZSI6ImY4NDlhZGE1LTYyMDMtNDFlYS04NTM1LTRhYmQyYWE5ZDVkYzpzdHJpbmc6U3BlY2ltZW4iLCJ0eXBlIjp7ImNvZGluZyI6W3sic3lzdGVtIjoiNjZlMzFiMWQtZmU0Zi00MDYzLWEyM2QtYTQwMDkxZTkyNWFlOnN0cmluZzpodHRwOi8vc25vbWVkLmluZm8vc2N0IiwiY29kZSI6IjEwY2VkNTZlLTRkNzctNDcwNC1iYThmLWQ4NjIxNTJmZjE1YTpzdHJpbmc6MjU4NTAwMDAxIiwiZGlzcGxheSI6IjVlNzI5MjA0LTgyN2EtNDA2Yy05YmI1LTM5ZTk2YTk4ZDEzZjpzdHJpbmc6TmFzb3BoYXJ5bmdlYWwgc3dhYiJ9XX0sImNvbGxlY3Rpb24iOnsiY29sbGVjdGVkRGF0ZVRpbWUiOiIyYTMxMzI4MS0wNjJjLTQwYmYtYTE5Ny1iMjc3YmRlMTA1MDU6c3RyaW5nOjIwMjAtMDktMjdUMDY6MTU6MDBaIn19fSx7ImZ1bGxVcmwiOiI3MzdlN2QzNy1kNjU4LTRmNzItYjYxMS1hNzI1YmE3OGJkNjU6c3RyaW5nOnVybjp1dWlkOjNkYmZmMGRlLWQ0YTQtNGUxZC05OGJmLWFmNzQyOGI4YTA0YiIsInJlc291cmNlIjp7InJlc291cmNlVHlwZSI6IjlhYWY2YTI3LTlmNzItNDIwMi05ZmQyLTA3NTRjNWM2MGFkMjpzdHJpbmc6UHJhY3RpdGlvbmVyIiwibmFtZSI6W3sidGV4dCI6ImRlNjQ3ZTZmLWVjNGUtNDIyMi1iMGVhLWE2MmI1YWQ2YzUxYjpzdHJpbmc6RHIgTWljaGFlbCBMaW0ifV0sInF1YWxpZmljYXRpb24iOlt7ImNvZGUiOnsiY29kaW5nIjpbeyJzeXN0ZW0iOiJjZjBkMDViMC1lNWQ5LTQwNDYtYWY3MS03NzM1YmU3NTU3MmM6c3RyaW5nOmh0dHA6Ly90ZXJtaW5vbG9neS5obDcub3JnL0NvZGVTeXN0ZW0vdjItMDIwMyIsImNvZGUiOiI5MzlmZDE0Ni00YjMyLTQ2YTgtODljMy0zMDhhNjNiMDQwNzE6c3RyaW5nOk1DUiIsImRpc3BsYXkiOiI1NmU0ZjgyYS00ZmRjLTRmMzMtOGIzNC1iOWVkZTEyYjc3OWE6c3RyaW5nOlByYWN0aXRpb25lciBNZWRpY2FyZSBudW1iZXIifV19LCJpZGVudGlmaWVyIjpbeyJpZCI6IjNhOWJkMDU2LWNiMDQtNDNmMy1hZDJiLTQxZjZhMDE5MzQyYzpzdHJpbmc6TUNSIiwidmFsdWUiOiI1Zjk0YWVmOC1jNDcxLTQ4ZjctYjczNi0wNTViODRkMTkzZDA6c3RyaW5nOjEyMzQ1NiJ9XSwiaXNzdWVyIjp7InR5cGUiOiI4NzM4OWE3Zi02ZDFkLTRjOTctOTg2ZC05YjM4Y2VlODBkYTQ6c3RyaW5nOk9yZ2FuaXphdGlvbiIsInJlZmVyZW5jZSI6IjdlMDdlZDJiLTA5YTgtNDljMS05ZmM1LTkyNmUwMTRmYTRlZTpzdHJpbmc6dXJuOnV1aWQ6YmM3MDY1ZWUtNDJhYS00NzNhLWE2MTQtYWZkOGE3YjMwYjFlIn19XX19LHsiZnVsbFVybCI6ImNkMWZiNjU4LTE4MjMtNGMzOS1hZDJlLWI2NjYyZjk4NmI2MTpzdHJpbmc6dXJuOnV1aWQ6YmM3MDY1ZWUtNDJhYS00NzNhLWE2MTQtYWZkOGE3YjMwYjFlIiwicmVzb3VyY2UiOnsicmVzb3VyY2VUeXBlIjoiNjVmMzAxYmItZDEzNi00YTg0LWFlZmItODc3YzJiMWUxOTg4OnN0cmluZzpPcmdhbml6YXRpb24iLCJuYW1lIjoiNTRmMDMwNDAtNzRhNy00ZmU1LWI3NDYtOGJjYWFkMjE4Y2VjOnN0cmluZzpNaW5pc3RyeSBvZiBIZWFsdGggKE1PSCkiLCJ0eXBlIjpbeyJjb2RpbmciOlt7InN5c3RlbSI6ImQ0ZWQ2YzBmLTgyNDctNDI3Ny04NGIxLTVjMWIxNjEyNzQ2MzpzdHJpbmc6aHR0cDovL3Rlcm1pbm9sb2d5LmhsNy5vcmcvQ29kZVN5c3RlbS9vcmdhbml6YXRpb24tdHlwZSIsImNvZGUiOiJiY2VmMTJjZC04MjljLTQ0MWItYjllYS00YzE0ODZlMjhkYzU6c3RyaW5nOmdvdnQiLCJkaXNwbGF5IjoiMmRiYWVjM2UtOGUyNS00NTAzLTllNTMtMjE4ZmJkMDkzMGMxOnN0cmluZzpHb3Zlcm5tZW50In1dfV0sImNvbnRhY3QiOlt7InRlbGVjb20iOlt7InN5c3RlbSI6ImY3N2JmYjM2LWE2OTEtNDU5OS04OTU5LWViYzk2M2NlY2QyNDpzdHJpbmc6dXJsIiwidmFsdWUiOiI0NTc1ZDM0ZC1hZTJlLTRhNDctODFmYS1kMDIxYjc4NTQyN2U6c3RyaW5nOmh0dHBzOi8vd3d3Lm1vaC5nb3Yuc2cifSx7InN5c3RlbSI6IjFkNWNmMzZmLWYyMjAtNGQ2Mi04MDE5LWYxOGZlMGY3MTdmNTpzdHJpbmc6cGhvbmUiLCJ2YWx1ZSI6ImIzOWY5M2E1LTJhYjAtNDFlNC1hMDYyLWFkMTRlYWI1NDQ4YjpzdHJpbmc6KzY1NjMyNTkyMjAifV0sImFkZHJlc3MiOnsidHlwZSI6ImQwOTBlODE3LWVkNzItNDc3Ni1iMWUwLWJkZjNmMWQzNDhjOTpzdHJpbmc6cGh5c2ljYWwiLCJ1c2UiOiJmMzdlOTJiNS03N2JlLTRkMDMtODA3Zi00MzNlYTAwNWE3NDk6c3RyaW5nOndvcmsiLCJ0ZXh0IjoiZjY2YTM1YzMtY2Y5My00ZDE4LWI0MzEtNmFhN2M5ZmI2YTdmOnN0cmluZzpNaW5pc3RyeSBvZiBIZWFsdGgsIDE2IENvbGxlZ2UgUm9hZCwgQ29sbGVnZSBvZiBNZWRpY2luZSBCdWlsZGluZywgU2luZ2Fwb3JlIDE2OTg1NCJ9fV19fSx7ImZ1bGxVcmwiOiJjNGFlZjM1Mi02NTk1LTQ1MWMtYmIzZi0xYTM2NzJmNWNjNjU6c3RyaW5nOnVybjp1dWlkOmZhMjMyOGFmLTQ4ODItNGVhYS04YzI4LTY2ZGFiNDY5NTBmMSIsInJlc291cmNlIjp7InJlc291cmNlVHlwZSI6IjQ0ZWRiNWRhLTMyYzctNDk1Mi1iMjgxLTNjODE0ZWNjZDcyYzpzdHJpbmc6T3JnYW5pemF0aW9uIiwibmFtZSI6IjIwMjY4Y2U0LWFjYWYtNDgwZC1hOTE3LTQ5MWZiZTc1ODg3YjpzdHJpbmc6TWFjUml0Y2hpZSBNZWRpY2FsIENsaW5pYyIsInR5cGUiOlt7ImNvZGluZyI6W3sic3lzdGVtIjoiNGZmNjI1MTUtZWZlYS00NGZiLTg4MTUtMjkzMGQzM2ExZjQ2OnN0cmluZzpodHRwOi8vdGVybWlub2xvZ3kuaGw3Lm9yZy9Db2RlU3lzdGVtL29yZ2FuaXphdGlvbi10eXBlIiwiY29kZSI6IjFlZTZiM2YyLTc3NjAtNGJkNS1iYjRhLWMxODM0NzdlYjJmZjpzdHJpbmc6cHJvdiIsImRpc3BsYXkiOiIxODM5YzZlMC0wZmIzLTQ5ZjQtOGZhNC03NGNjYTcxYmQ2NTg6c3RyaW5nOkhlYWx0aGNhcmUgUHJvdmlkZXIifV0sInRleHQiOiIxYjliOGExNC1jNWJhLTQ0YzItYWU4Yy03MmJjNTM1NWFkMzU6c3RyaW5nOkxpY2Vuc2VkIEhlYWx0aGNhcmUgUHJvdmlkZXIifV0sImNvbnRhY3QiOlt7InRlbGVjb20iOlt7InN5c3RlbSI6IjAyZTgyMTJhLTk1MGUtNDI3Mi04ODk2LTg1NGZiNmQ2YjliNzpzdHJpbmc6dXJsIiwidmFsdWUiOiIyNjA0ZjEwYS02YTc0LTRlYTMtYWU4ZC1kMGZkNzc3NjY1OTk6c3RyaW5nOmh0dHBzOi8vd3d3Lm1hY3JpdGNoaWVjbGluaWMuY29tLnNnIn0seyJzeXN0ZW0iOiIxMjkwYTVmZi01NGUyLTRiYzEtODAwYi0zNWY4YTQ2ZmZiNTI6c3RyaW5nOnBob25lIiwidmFsdWUiOiI4YTYyZWJlMi0xMzlmLTQzZjYtYmZlMC04MzgzNzdiYmQ2NmI6c3RyaW5nOis2NTYxMjM0NTY3In1dLCJhZGRyZXNzIjp7InR5cGUiOiI1ZGM2YmUxYS01ZjU5LTQxNmYtYTZlYS0xNmMwNjM5MDdjZjE6c3RyaW5nOnBoeXNpY2FsIiwidXNlIjoiODQwZjI0NzMtOTU5OC00NTMwLTkzZjItMzZmZDdlMGU3YjEzOnN0cmluZzp3b3JrIiwidGV4dCI6ImUzNWI4ZWNiLTE3MzItNDRhZC1hOGJlLTIwY2ViNDFjM2E1MjpzdHJpbmc6TWFjUml0Y2hpZSBIb3NwaXRhbCwgVGhvbXNvbiBSb2FkLCBTaW5nYXBvcmUgMTIzMDAwIn19XX19LHsiZnVsbFVybCI6Ijg4NDg3OGExLTcxODYtNGZmYS1hZDNjLTg0M2IxMTU4NDQyMTpzdHJpbmc6dXJuOnV1aWQ6ODM5YTdjNTQtNmI0MC00MWNiLWIxMGQtOTI5NWQ3ZTc1Zjc3IiwicmVzb3VyY2UiOnsicmVzb3VyY2VUeXBlIjoiZjNmMjY4ZTItYjA4My00M2I1LWJjNjktY2UxYzc1MDE5ZGUyOnN0cmluZzpPcmdhbml6YXRpb24iLCJuYW1lIjoiZmE0ZWU4ZDAtOTc2My00NzQ2LWIwNjYtZjQwZTkwZTE1NjEwOnN0cmluZzpNYWNSaXRjaGllIExhYm9yYXRvcnkiLCJ0eXBlIjpbeyJjb2RpbmciOlt7InN5c3RlbSI6IjU5M2UzYTUyLWVmM2MtNGQ4Yi05YmRiLWY4ZDhjZmVlMjU0NTpzdHJpbmc6aHR0cDovL3Rlcm1pbm9sb2d5LmhsNy5vcmcvQ29kZVN5c3RlbS9vcmdhbml6YXRpb24tdHlwZSIsImNvZGUiOiJhODU3MzBjMC01YzY2LTRlNTAtYWM3My0wMWM1YTM4OTZmYjE6c3RyaW5nOnByb3YiLCJkaXNwbGF5IjoiZjY5NGUwZjMtNzlkMy00ODQ4LThjMzktYmE5OTBmYThlMGVmOnN0cmluZzpIZWFsdGhjYXJlIFByb3ZpZGVyIn1dLCJ0ZXh0IjoiMzQxZWRmMTAtZjczYS00NTY4LTkwN2MtMDQxOTM0MjI1YWY0OnN0cmluZzpBY2NyZWRpdGVkIExhYm9yYXRvcnkifV0sImNvbnRhY3QiOlt7InRlbGVjb20iOlt7InN5c3RlbSI6IjUwZjBjZjk2LTE0ZDMtNDgxOS1hNzY1LTdkNDEzY2ZiMjc1MTpzdHJpbmc6dXJsIiwidmFsdWUiOiI2NDRmMGRjYy0yODk3LTQ4YzEtYjAzMi00MjRmOGQ1ZGVlZWQ6c3RyaW5nOmh0dHBzOi8vd3d3Lm1hY3JpdGNoaWVsYWJvcmF0b3J5LmNvbS5zZyJ9LHsic3lzdGVtIjoiYWRjZTBhMWQtOGM4Zi00ZDUyLTgzZjUtMWVhYThiMTYyZDIzOnN0cmluZzpwaG9uZSIsInZhbHVlIjoiODExMjg4YjEtNTU1ZS00MzJlLTk0OTktYTdiOTQ0ZTExMmExOnN0cmluZzorNjU2NzY1NDMyMSJ9XSwiYWRkcmVzcyI6eyJ0eXBlIjoiZGIwNmNhN2MtNWYwNi00ZGVkLTliODAtNWUzZWNhZDY4M2MwOnN0cmluZzpwaHlzaWNhbCIsInVzZSI6IjhhYjdlMWQ1LTE2NzItNDEyYS04MmUyLWZlYzc4OWZmNTZlZjpzdHJpbmc6d29yayIsInRleHQiOiI4MWU1MWIwNi1jN2ZlLTRiMDYtODFlMS0zNDM1MzM2NTUwZTY6c3RyaW5nOjIgVGhvbXNvbiBBdmVudWUgNCwgU2luZ2Fwb3JlIDA5ODg4OCJ9fV19fV19LCJsb2dvIjoiN2MwYjIzMTktNDYxOS00N2EwLWJkOTYtYWMzOTA0MjgwYTIyOnN0cmluZzpkYXRhOmltYWdlL3BuZztiYXNlNjQsaVZCT1J3MEtHZ29BQUFBTlNVaEVVZ0FBQWZRQUFBRElDQU1BQUFBcHgrUGFBQUFBTTFCTVZFVUFBQURNek16TXpNek16TXpNek16TXpNek16TXpNek16TXpNek16TXpNek16TXpNek16TXpNek16TXpNek16TXpNek16ZUNtaUFBQUFBRUhSU1RsTUFRTCtBN3hBZ24yRFAzekJ3cjFDUEVsK0kvUUFBQndkSlJFRlVlTnJzbmQxMjJ5b1FSdmtISVNITit6L3R5VWs5b1RFQ1ExYlRCYzIzYnlOczBCNUdJREFSQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQWsrSWsrSWR4NGc1TjRCOUdRL3JQQTlKL0lQZlNnd0wvTUVFQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUR3UDVaUG9QNXI3RkpLQWY3Y3VmQmloUE5Ta1g1aGxBOXUrRHNQN2RYL0pLMVAyVlBpU0lvZWJFckx3Vmg1WngrOEMxWTIyWXRQMEZwZjZoZGVhK21xMVdsaXhmZWo2UmNEeGowOXN3WGJiZUJRcGlqdWcyMGFqL1NFOGJ2bzVoRXVhdkF1U0twUWZKeFRHOTFnVXJDVjZqU1FFMG9Qa2U0d3VrZTcwNUVxcExOV3h0TXRTazRqdlhHbGQrdExseHZWTU5uYWtEN21FbmRZVFZXU25WODYwV1VYbDM0Uk15N0JlbXB5R3pON3BBYm1YRUE2YmZ2SzB1MzJ1VEZLS1ZNMHIwWXcxTVRjRnZwOGlWTFBEMCs5Z0hReSs3clNmM2VlanAySHVGY3NtbGRpRXowRnpLWGZTUnczcWUwOFhxZDlkUDZRS09Obmt1NGxHM05TYi9SQnRLdEt0MXR0ZEJKaVliMlZJN2JyYzd0YzhJWW90SnpIVUIwYytPK1QzclRRdUxLc1pScXB6a1RTN2RaSTR2bytxSm5kRUdPOEV6ZWN5amFjNi9JVE4yS09XYVVMSVQvYUxkZVVucXBkaTdWVzIrS3ljMjlGTDNzN2UzaGk1TFRTaGVXV3B5V2xINFh6bXZXam5pT2lGTjNZV0RpdldJOTJXdWs1Y3QyQzBwM0p6bDlZTjY2V0k1SVYvVnlGODZyMWExN3BINVVNQzBwWC9Ed1hWVTUyNEtzNVlnRFptTDR6R3oxdzgwcDMzUGoxcE12Y2krdGMyY0ZJam1oSDJkV1ZmdWFWTHVMank5ZVR6Z3FPcnFld3YwdnVtLzFLUjQrMmE2RGg1cFhPN1Y5TytzNEtSSlBBRHV4Tmp0akZDQ2svQ2x0RXpnZnpTdGVyU3ZkWlFaZURveXlxeFFndVIxbFhtQmxJLzlQU2ViWnBiT2U4Yml2dDJiRks5WWFLNGVIZTdOTE5hdExQM3FHWUxmTDcxUm9NdkI2WHU5NkozVFd0OUxUb1FNNXptOFlmeGJISUVTUFpYWFcvdG92VFNvK1BxRnhOZXN3WnFqTy9YMDlPdkJnaTlPY0h3N2xsVXVrY3YrZGkwcm5lcWY5OXVYb0tnbE1Nd2FsbDd4L215MG1sUDVwaVZudjNmdVorMTkzeG5wVFlMejNTamVqUExYcE82VHRYYnpYcGZJVWNlSkhtUHNYQUpzYkkrYUw3ZnZzcHBWc09YN3VhZEo5RnZ1VDYzUHhzWkFRM1VNeHlnTHlXdnNrNi9sdWt1NDBmYjh0dG9sREZGYjFaUVE2L21Sa3YxaVc5aTFKNkMvMWFlakFjdlFQVm1VdDZGQjJjbjI2SnpETzRUc2FMY1dlYVRibzdJbjA0WDA4Njk2WHhUbnJrbXpHQ0hpbW1KcEx1TmFQaTcxZitLT2t0ZTVJSzlPclM3NGluZ1BTZkpkMW9JU0Q5WjBtL2hQaEIwbysvTGQzTU1HVXJTVTY4czl5VXpYU08zc3VoVytCaCtKajBveXoyc25acWdwY3pkNWl3cHZSdm1LZlhwWS9QMHllU2ZzZ0hPaGxpd3RMUzdjQlNpUjFhWkZQMzBxK0J0M2ZYYks5aFEyVHIrNHJTYys4ZGZsWENPMmw2cFkrUElzNXBGMXhzNGttYlhWQjZ6MEpXUlJkSCs2QjB3OFZlb3lkZVdsVjg0eGFVTG52WDA4dkV6Tm4rSEpPdSt0ZlQxY1NiS1BMZXd2V2tjL2MxL1l0czRTbEorREhwdW5zRjMwNjlYU3J3N1ZoUWVsNGdITjNRdUhPOGpFay9POGNDK1VvL3BYUit2RzBMU24vWlh4bFh5SW9jNjBQU2hlbGR3dmR6YjRIVzNJNzFwTy8wd0hZcU9JcDh2NDFKVDUyVE5qZjVqeDI0Zm1FOTZXTHJHNy9ic29NNmVoQ0dwSjhzMC9aVjNrOHFuVE9kWDFCNjZIT2diNGI1S1JmdGw1NGZDN292eXZaWnBYdDZKeTRvM1pxZWRPdk1UZHNsUFVoRDBybFd4dlZNRnRTMFAxVU9uUHZXazg0WGRiMERJWFcva0hpTVNMZW03ck1NS0RtdDlKMEhtZ3RLLzNCZzdHaGdPR0xDZ1BUOGFmcDFwZFRFeDQ4ODZuZ3RLRjJjOU9wc2dWRGJPS0NKT1Fha2krMVZyRmkrd3JpSnBmTmEvb3JTaGNyVzI4NmpMWXN5eWZaTGw4U0V0bk02NWoxU0xIK3dYVkc2amMwRFlJOTg2RnVqS0puUUxWMGMxTXJ3N3NPNW4vZnd3RGZrb2o5Z2ZENG96aHlGQVVWTXFCUmxZckNkMG9VblJya2l5RXpPUEZOTEZ6VHpUNVZsQlhkM09tOG96a0J0T09kRFBaa1U5azkvUENwTGtIYXJuWlVmSWhYT3YwLzZJU3YwU09jdmovMWI5dHpma041RzN4N2ViZEloMzRXZkY2dHBEcnJZSzZQVXBkLzRmSlMzYnBYYXJ0T0pOK1NSREJYT3YwbDZtNkV6WjF6MzVsdzlrM1JPMDFXTUZCVTRINCsyMWxNYmI4WHMwdmx2WVZIcDNQVXFLQ2NhT0RVc25iTkxTUjVjVEMrZForcHBWZWxDbkthMTE3ZU5UTlFrU1ZGaVUydFArUXJTT1Z2WlphVUxxd3Z0UENoL2pkTWIzUk45OVFPa29qdjhMc1FTMGsvTzcrdEtmK05NVDk2TlAwVXZMdmluUm05Sm4yNHdWcmJEQ2JHSWRGNHhWQk5KL3hKU2U2VWVvL0JqLzlJLzdEeTBQdnJuSnk1b3BTSVJSWlgwYVFVQUFQelgzaDNVQUFDQVFBeDdZQUQvYW5GQkNOZGFtSUFCQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFEQW1tb2VLOUh6aUI1STlFQlhueDhBQUFBQUFBQUFBTEJtQUlaS216V0lueHlPQUFBQUFFbEZUa1N1UW1DQyIsImlzc3VlcnMiOlt7ImlkIjoiOWJlZTRiNWYtMjIwZi00ZTljLTg3YTYtZmE1YWJiNDY5ZTYyOnN0cmluZzpkaWQ6ZXRocjoweEUzOTQ3OTkyOENjNEVmRkU1MDc3NDQ4ODc4MEI5ZjYxNmJkNEI4MzAiLCJyZXZvY2F0aW9uIjp7InR5cGUiOiJiNGIxYjc4Ny05NGQ0LTQ4NmEtYTBhZC04YmNjNzQwNGUzMDY6c3RyaW5nOk5PTkUifSwibmFtZSI6IjVhMTEwNTEwLTYyMzAtNDM5Ny04ZmYyLTEyNDY1ZDgxZGJhMjpzdHJpbmc6U0FNUExFIENMSU5JQyIsImlkZW50aXR5UHJvb2YiOnsidHlwZSI6Ijc0MDk0ODlhLThhNmYtNDJkMC04NDZhLTYzZmIyZTYyOThmYjpzdHJpbmc6RE5TLURJRCIsImxvY2F0aW9uIjoiMDRmNDRkZjEtMGQyMS00M2E5LWI5YmMtNmJjNTRhYjhjYWExOnN0cmluZzpkb25vdHZlcmlmeS50ZXN0aW5nLnZlcmlmeS5nb3Yuc2ciLCJrZXkiOiIwYTBmNTcwYS0xNWQ5LTRjM2EtYmQyYi0xMTM1ZTNhNzU0Njk6c3RyaW5nOmRpZDpldGhyOjB4RTM5NDc5OTI4Q2M0RWZGRTUwNzc0NDg4NzgwQjlmNjE2YmQ0QjgzMCNjb250cm9sbGVyIn19XSwiJHRlbXBsYXRlIjp7Im5hbWUiOiI2ZGRkNGU5Yy1jMWE1LTQ1MTgtYmVjNi0wYzcxMmZkOWY3MzQ6c3RyaW5nOkhFQUxUSF9DRVJUIiwidHlwZSI6ImFhZTYzZTA0LWE1YmEtNDg5My05ZWE5LTk2MGMzYTE4MDdlZjpzdHJpbmc6RU1CRURERURfUkVOREVSRVIiLCJ1cmwiOiJmMThkYjlhNy02NTYyLTQ4MGMtOTFlZi04NDM0NzA3ZjQxOGQ6c3RyaW5nOmh0dHBzOi8vaGVhbHRoY2VydC5yZW5kZXJlci5tb2guZ292LnNnLyJ9fSwic2lnbmF0dXJlIjp7InR5cGUiOiJTSEEzTWVya2xlUHJvb2YiLCJ0YXJnZXRIYXNoIjoiMGFhOGJiM2QyMzJlYTgwMjEwMzAwODExMGZhZDgzNzcxZWEzNjMxMWUxYzU5NjVlZjIyZmRjOWY1ZGRiMzBhZCIsInByb29mIjpbXSwibWVya2xlUm9vdCI6IjBhYThiYjNkMjMyZWE4MDIxMDMwMDgxMTBmYWQ4Mzc3MWVhMzYzMTFlMWM1OTY1ZWYyMmZkYzlmNWRkYjMwYWQifSwicHJvb2YiOlt7InR5cGUiOiJPcGVuQXR0ZXN0YXRpb25TaWduYXR1cmUyMDE4IiwiY3JlYXRlZCI6IjIwMjItMDMtMjhUMDI6NTA6MTYuNDQxWiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsInZlcmlmaWNhdGlvbk1ldGhvZCI6ImRpZDpldGhyOjB4RTM5NDc5OTI4Q2M0RWZGRTUwNzc0NDg4NzgwQjlmNjE2YmQ0QjgzMCNjb250cm9sbGVyIiwic2lnbmF0dXJlIjoiMHg1YjY3NTVmZGZiZmJmNzUyNDhhY2M5MWY5YmFjN2RlOWQwYTg0YWUyZDNkNjMxZTQ4YThhMzE3MGQ3NDM3YzJhNWJjMjkxMWY4MDliN2YxY2I2MDY2YjNmOGQ5YjE2MDUzNGRlZGZiNjkyOWM1NTI0MjcxMGM1ZjIyYTA1YzNmNDFiIn1dfQ=="
+      }
+    ]
+  },
+  "signature": {
+    "type": "SHA3MerkleProof",
+    "targetHash": "47c88a81e2448719b1f905c1ff5f8a696efff8c2ea643602846804be5997f99c",
+    "proof": [],
+    "merkleRoot": "47c88a81e2448719b1f905c1ff5f8a696efff8c2ea643602846804be5997f99c"
+  },
+  "proof": [
+    {
+      "type": "OpenAttestationSignature2018",
+      "created": "2022-06-22T03:31:17.028Z",
+      "proofPurpose": "assertionMethod",
+      "verificationMethod": "did:ethr:0xE39479928Cc4EfFE50774488780B9f616bd4B830#controller",
+      "signature": "0x0527151cfdd8ba0cb714074959ad503034d7e4d97a66f0c242d5882022b5f3bc31ae15f10070ac211af16746401c4d8ef40c429d2d4fc1e5cb1266a223c702331c"
+    }
+  ]
+}

--- a/utils/fixtures/vac_v1_healthcert_eth_revoked.json
+++ b/utils/fixtures/vac_v1_healthcert_eth_revoked.json
@@ -1,0 +1,268 @@
+{
+  "version": "https://schema.openattestation.com/2.0/schema.json",
+  "data": {
+    "id": "770e1ff8-bb50-44d8-8d51-f57da359628f:string:bc44e018-790a-4801-8998-12bc0b455024",
+    "name": "05802570-11b7-4344-9685-e199db9082d4:string:VaccinationHealthCert",
+    "validFrom": "466a8642-839c-4443-b8d6-35f47126b40d:string:2022-06-30T03:31:26.069Z",
+    "fhirVersion": "3b13f1e8-b951-4085-93e0-55911cf70150:string:4.0.1",
+    "fhirBundle": {
+      "resourceType": "27c7758d-d9b7-49fb-bddb-059a45a3ba28:string:Bundle",
+      "type": "200ef93d-d259-47ad-9f5c-b992c10daf40:string:collection",
+      "entry": [
+        {
+          "fullUrl": "cbead1fd-fcba-4664-a7b7-0f0845ebcbb7:string:urn:uuid:400f8bc1-4ca8-4c22-85ec-a15561da345e",
+          "resourceType": "36880041-fc35-4a7a-8b7a-16469ab786e2:string:Patient",
+          "extension": [
+            {
+              "url": "cfa5e5be-9150-4a3d-b720-7f3eff6b4dba:string:http://hl7.org/fhir/StructureDefinition/patient-nationality",
+              "code": {
+                "text": "560a5a4c-dd73-41d1-955c-ef3f2841c68e:string:SGP"
+              }
+            }
+          ],
+          "identifier": [
+            {
+              "type": "8225ca8a-1f46-45b1-943b-2e15227b20fe:string:PPN",
+              "value": "286b807e-cd11-4a79-9510-fbf2fda7a967:string:T1111111J"
+            },
+            {
+              "type": {
+                "text": "72b06f7d-e057-4480-a3be-97a0c44ad8da:string:NRIC"
+              },
+              "value": "5e8c2200-839f-44f5-a496-1f30e0e0972d:string:T****111J"
+            }
+          ],
+          "name": [
+            {
+              "text": "b66d6854-b98f-46fe-9452-fb8f8f38ab38:string:Yi"
+            }
+          ],
+          "gender": "faa8e550-80d9-4fd6-bd98-639f211f283b:string:other",
+          "birthDate": "de7156fa-1430-4b5b-980e-640926d5e192:string:1993-10-10"
+        },
+        {
+          "fullUrl": "d981b210-ed10-431c-bd82-d4add9a837cb:string:urn:uuid:f379f40a-5481-4266-8146-856eb09cb465",
+          "resourceType": "45d62178-8963-4ff5-850a-27ad0eb2c69e:string:Location",
+          "id": "3eddf163-b085-4daa-a0ac-cbd013b6cb0a:string:123",
+          "name": "2744893b-c5ea-44e1-a81f-23ae6e604b3a:string:Vaccination site approved by Ministry of Health (MOH), Singapore [123]",
+          "address": {
+            "country": "9d409685-317d-4f58-97ff-1e7c28ba8baa:string:SG"
+          }
+        },
+        {
+          "fullUrl": "1c648aba-c2f3-41ab-a4c9-f708ad43f8ad:string:urn:uuid:41845aa4-94fa-40e5-9219-90b0fdd755a4",
+          "resourceType": "bb22dccf-e6ad-4093-99bd-2d85e8eb8e29:string:Location",
+          "id": "05c0ae6e-dd12-400f-9fcd-fd1db133e06d:string:234",
+          "name": "8c2cad6d-7db2-40b3-ba00-e96bc8d0c3e8:string:Vaccination site approved by Ministry of Health (MOH), Singapore [234]",
+          "address": {
+            "country": "2a6f91e7-ac43-4778-86e1-dc1ff3ae4b58:string:SG"
+          }
+        },
+        {
+          "fullUrl": "27c2e0d6-ccd5-4e10-b4b7-28bdadc61f7c:string:urn:uuid:5f1e882b-c1d1-45de-836d-0f3b2ec50537",
+          "resourceType": "18a9c016-25b3-4b49-9eab-c80fe6bdafe8:string:Location",
+          "id": "eab5e8d2-90fc-413a-9507-393e8806ff61:string:123",
+          "name": "acf02f1a-838e-40ac-b200-8baf40b2381a:string:Vaccination site approved by Ministry of Health (MOH), Singapore [123]",
+          "address": {
+            "country": "fd51acc2-1d5a-4ecd-adf5-4599b04485e9:string:SG"
+          }
+        },
+        {
+          "fullUrl": "5c7c3bdd-ef90-4232-bfc7-ceb46d18e3d6:string:urn:uuid:66e6a80f-c194-4e39-bc6d-f55c6a3619e4",
+          "resourceType": "ae0afc5c-8e49-4c21-92dc-cad987705120:string:Immunization",
+          "vaccineCode": {
+            "coding": [
+              {
+                "system": "48cc7a27-afd0-4834-82ba-1bc1af7e33d4:string:http://standards.ihis.com.sg",
+                "code": "63b640da-fdae-4839-9af0-3406d7a675f4:string:3339641000133109",
+                "display": "2b2bcac8-2c38-4eeb-a529-f9233db1b183:string:PFIZER-BIONTECH/COMIRNATY COVID-19 Vaccine [Tozinameran] Injection"
+              }
+            ]
+          },
+          "lotNumber": "31398bab-2c75-4f2a-8a84-9630c7d50552:string:B123",
+          "occurrenceDateTime": "59b9d8bf-16d0-4c1a-a4c4-6e6ae4a268fb:string:2022-01-02",
+          "patient": {
+            "reference": "5558fd60-b65a-4bc5-b9fd-ddf51894f1d8:string:urn:uuid:400f8bc1-4ca8-4c22-85ec-a15561da345e"
+          },
+          "location": {
+            "reference": "86b57d6d-089b-4dae-9600-e1bb38ffc0d5:string:urn:uuid:f379f40a-5481-4266-8146-856eb09cb465"
+          },
+          "performer": [
+            {
+              "actor": {
+                "display": "f1f1e809-8c99-45c2-800b-9714a10046c5:string:Designated vaccinator by MOH-approved vaccination site"
+              }
+            }
+          ]
+        },
+        {
+          "fullUrl": "ba8d2a72-139a-46b5-8028-6a46ae7afd59:string:urn:uuid:32d2398c-fffd-4c46-b6f2-4c0959b0e92f",
+          "resourceType": "3db997ba-172a-4a2e-a717-3c3a0e40239d:string:Immunization",
+          "vaccineCode": {
+            "coding": [
+              {
+                "system": "b9500754-8f23-47ad-8350-c0679a51c9e2:string:http://standards.ihis.com.sg",
+                "code": "bd2f0b59-c0d3-4046-ad0a-adc25f7c5ed1:string:3339641000133109",
+                "display": "6cc9f2dd-6e07-4844-8184-d560fa848578:string:PFIZER-BIONTECH/COMIRNATY COVID-19 Vaccine [Tozinameran] Injection"
+              }
+            ]
+          },
+          "lotNumber": "d7d22c08-0005-46dc-a706-d7bc0780ba67:string:B234",
+          "occurrenceDateTime": "2406af21-a4c7-476b-ae9d-96ecf0912eb6:string:2022-02-02",
+          "patient": {
+            "reference": "b1299de0-c6a4-428e-bd93-786ddb43da9c:string:urn:uuid:400f8bc1-4ca8-4c22-85ec-a15561da345e"
+          },
+          "location": {
+            "reference": "fd717f93-607b-435d-accb-d32508e178fc:string:urn:uuid:41845aa4-94fa-40e5-9219-90b0fdd755a4"
+          },
+          "performer": [
+            {
+              "actor": {
+                "display": "afbc42d9-487b-4bec-bf45-e644f3f21a74:string:Designated vaccinator by MOH-approved vaccination site"
+              }
+            }
+          ]
+        },
+        {
+          "fullUrl": "1234917f-04b9-4228-9d6a-2f3993c7ce67:string:urn:uuid:71f9d111-edbb-4b38-a793-a8dcabaaf2fd",
+          "resourceType": "e5e229bb-6e20-47ac-98e5-8319aa58e728:string:Immunization",
+          "vaccineCode": {
+            "coding": [
+              {
+                "system": "2b373783-a52a-41fc-98cd-44f2317941f8:string:http://standards.ihis.com.sg",
+                "code": "f9b201d8-6a1a-4846-8d5f-04e8e18586ea:string:3407851000133103",
+                "display": "77d87f9b-4c5b-47ea-bc64-2c32eaf146bc:string:MODERNA/SPIKEVAX COVID-19 Vaccine [Elasomeran] Injection"
+              }
+            ]
+          },
+          "lotNumber": "5e57edf7-7a11-47da-b774-380f940b167d:string:C322",
+          "occurrenceDateTime": "a43bed27-139d-4c84-b379-0e9290c5c877:string:2022-04-02",
+          "patient": {
+            "reference": "fabacc3c-8f9f-467c-986f-6578f874a631:string:urn:uuid:400f8bc1-4ca8-4c22-85ec-a15561da345e"
+          },
+          "location": {
+            "reference": "693dd195-3617-428d-a86f-160bc3f3dc21:string:urn:uuid:5f1e882b-c1d1-45de-836d-0f3b2ec50537"
+          },
+          "performer": [
+            {
+              "actor": {
+                "display": "9ca7c2d0-a3ae-4f77-b34f-a41c68e66b8e:string:Designated vaccinator by MOH-approved vaccination site"
+              }
+            }
+          ]
+        },
+        {
+          "fullUrl": "112874d2-603a-4f09-95ee-3383383b055a:string:urn:uuid:0919b448-2613-450f-a505-c0ab1dc2cab1",
+          "resourceType": "910d8548-759a-4cc3-a934-68fb8ad00c20:string:ImmunizationRecommendation",
+          "recommendation": [
+            {
+              "targetDisease": {
+                "coding": [
+                  {
+                    "system": "3d14276a-8854-4c29-81e6-01f54a01f51a:string:http://snomed.info/sct",
+                    "code": "4590c93c-1173-4ca1-bc3d-3e0a78fd0697:string:840539006",
+                    "display": "b11c300b-1525-4358-96e4-82edb10020df:string:COVID-19"
+                  }
+                ]
+              },
+              "forecastStatus": {
+                "coding": [
+                  {
+                    "system": "c1f37378-4b81-4eec-9a35-fbc6d8d4570b:string:http://snomed.info/sct",
+                    "code": "9f421521-5345-4165-9030-4bc711b0b1b3:string:complete",
+                    "display": "6ab311d7-2862-4f49-9767-a7d0a627e9b8:string:Complete"
+                  }
+                ]
+              },
+              "dateCriterion": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "9c075856-fd00-4c42-984f-830d47ea3382:string:",
+                        "code": "7b18a737-4547-4c1e-88ed-4514a5360c77:string:effective",
+                        "display": "beb9090e-426a-47f8-a081-1df1dc586808:string:Effective"
+                      }
+                    ]
+                  },
+                  "value": "a65bfec2-53f4-4105-99e6-c35f8c7e8a63:string:2022-02-20"
+                }
+              ]
+            }
+          ],
+          "patient": {
+            "reference": "5177e9b4-7b9f-44e3-9f5e-fdba6470c9d1:string:urn:uuid:400f8bc1-4ca8-4c22-85ec-a15561da345e"
+          }
+        }
+      ]
+    },
+    "issuers": [
+      {
+        "name": "a5e4a9db-2af6-424e-b18a-2979dca4984a:string:MINISTRY OF HEALTH (SINGAPORE)",
+        "id": "e4014712-9a71-498d-befd-ac2dddc5ada4:string:did:ethr:0xfe0e8e2bea0068d4bdb1df5ce0d4fec585546c17",
+        "revocation": {
+          "type": "02e5337c-f1ad-448c-b788-25695e46760a:string:REVOCATION_STORE",
+          "location": "387e8982-59d2-44e8-806c-5296a4d1a14c:string:0x7384702915962d70Ef202Ffb38152c4c89cD98dA"
+        },
+        "identityProof": {
+          "type": "bf1178da-42ea-4a71-a365-86ef35aa7ab0:string:DNS-DID",
+          "location": "158f8818-6e15-4cd1-8eaa-330f743f8485:string:healthcerts.moh.gov.sg",
+          "key": "0fbe265b-820b-458e-b85c-c8695d50ca9a:string:did:ethr:0xfe0e8e2bea0068d4bdb1df5ce0d4fec585546c17#controller"
+        }
+      }
+    ],
+    "$template": {
+      "name": "3a99893b-6b74-4f21-827c-e9bb202e274e:string:VACCINATION_CERT",
+      "type": "3395a657-1693-4a2b-9f4e-0db81f9ed29b:string:EMBEDDED_RENDERER",
+      "url": "d845df95-9891-40b4-b96f-e18d15678014:string:https://healthcert.renderer.moh.gov.sg/"
+    },
+    "notarisationMetadata": {
+      "reference": "9f49e1b1-0d9b-433d-9f65-018d156a99a9:string:bc44e018-790a-4801-8998-12bc0b455024",
+      "notarisedOn": "811e8938-5703-4d1d-812a-5f245633b2c2:string:2022-06-30T03:31:26.069Z",
+      "passportNumber": "8cba49ce-16eb-49c8-a4aa-6fb9898bcd38:string:T1111111J",
+      "url": "cfa59b3d-ef7a-4486-bf8e-fe8e82302ab7:string:https://www.verify.gov.sg/verify?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-vaccine.storage.aws.notarise.gov.sg%2Fdocument%2Fdb98a368-f731-423f-b503-00f9272d784f%22%2C%22permittedActions%22%3A%5B%22VIEW%22%2C%22STORE%22%5D%7D%7D#%7B%22key%22%3A%22b2525c1fdcf23dbce33108b02705e33f0a4d0c755961e6137452b3f5fd15e476%22%7D",
+      "signedEuHealthCerts": [
+        {
+          "type": "b31de1b5-6fa9-4fda-bb03-9982121d1dfc:string:VAC",
+          "expiryDateTime": "9372dd81-484a-401d-b8b1-af06f3843641:string:2023-06-30T03:31:21.050Z",
+          "vaccineCode": "cba9601e-7e30-403d-9dcc-605d94ff8568:string:3339641000133109",
+          "dose": "5507bde5-7b36-42e4-be11-3ba416533ad3:number:1",
+          "qr": "91c3a4b5-fb87-466e-86be-b1a6b01fd8fb:string:HC1:6BFHZAGZ9OJ2:O2-*MRE1I1M5Z4A.83QM4QV44U5U8OR6RPAAW81QAL1KP.C3ZS..R93F34GTHMI/BK9FYN0K:AQX8$K8IBL$Z7C55/MQFCFKQI0NG4%4/O3I6ET07OP6/ 7ZCVR:L855CKCJAWP+Q87IP*HY2TNVU+8LP2W/-T/EITYS 5PBUSF53LX2XIR11Q6SC.A2D9GG/IP4F0SFNSJ5GPTUH69E.J1BG3354PROC 8K3E/1O3N4*UO+4EEEERP0YPL38D27JKF1FZK1MJ6E8W57YWGSCG5PHK1HQ1EHROZ77D61C42X589RO6$1BH3WS67F6:OPZBPNTG%TE6GMZ3N8JUQF7::LI8SN5B:D6NG9MKFGI79+TGVNW$K1K6ANEW2U-A8ZA7%4DL0KH75AO0ZGCXM2R2JDGJN9QULEWKA3TB%R3UVBA 7ZBORUTRCH RED0UJYNC+JZ0FFINNYE*LI4K75:IZ$SVWE5-N4XC2N343G$D33CH$1H-YRLBEBE8WR608PUYAXT2HX47CM:86FBM.BG%74DA3NK915GIXG%OBU55RN1ZZ5Y71SK8*88QHAT4G:5JXTLTRLD90NSM.YCUNA:LU%PK6N5 A4P55T3L:Z9GX1%W0Y42:N13X0.BLRFGOR15V26+MVO279H%F88UO V6W49SCABSG.XIY.NL/T1L1::IH40-C30D51NUVJQNR63H4.76BRB617566M486KALG617N9/QH$S310D78ZI6EIH COYOCHERBZ1VG9OPMDL35*H4F8JBFT6BS7R$1R-9F3%569K3U58ETB:4B/ODA43+7LLUDXSU4I9RL5WE8A5JR9QDJ6Y2N66-J4G28JGB%186$CG34$%MC/OR.V+IFZ8WJ6E3SBD-HDOA55O.IIFEVHPBH287/EHVNHKT*3U2LMXSV+CFWJS*6U*8S738D28Y2B+6P::OX5HJBQJWOY*I5WQR6DV001AKB0",
+          "appleCovidCardUrl": "bb86c457-514b-483e-b733-d1eb69fc3e5a:string:https://redirect.health.apple.com/EU-DCC/#6BFHZAGZ9OJ2%3AO2-*MRE1I1M5Z4A.83QM4QV44U5U8OR6RPAAW81QAL1KP.C3ZS..R93F34GTHMI%2FBK9FYN0K%3AAQX8%24K8IBL%24Z7C55%2FMQFCFKQI0NG4%254%2FO3I6ET07OP6%2F%207ZCVR%3AL855CKCJAWP%2BQ87IP*HY2TNVU%2B8LP2W%2F-T%2FEITYS%205PBUSF53LX2XIR11Q6SC.A2D9GG%2FIP4F0SFNSJ5GPTUH69E.J1BG3354PROC%208K3E%2F1O3N4*UO%2B4EEEERP0YPL38D27JKF1FZK1MJ6E8W57YWGSCG5PHK1HQ1EHROZ77D61C42X589RO6%241BH3WS67F6%3AOPZBPNTG%25TE6GMZ3N8JUQF7%3A%3ALI8SN5B%3AD6NG9MKFGI79%2BTGVNW%24K1K6ANEW2U-A8ZA7%254DL0KH75AO0ZGCXM2R2JDGJN9QULEWKA3TB%25R3UVBA%207ZBORUTRCH%20RED0UJYNC%2BJZ0FFINNYE*LI4K75%3AIZ%24SVWE5-N4XC2N343G%24D33CH%241H-YRLBEBE8WR608PUYAXT2HX47CM%3A86FBM.BG%2574DA3NK915GIXG%25OBU55RN1ZZ5Y71SK8*88QHAT4G%3A5JXTLTRLD90NSM.YCUNA%3ALU%25PK6N5%20A4P55T3L%3AZ9GX1%25W0Y42%3AN13X0.BLRFGOR15V26%2BMVO279H%25F88UO%20V6W49SCABSG.XIY.NL%2FT1L1%3A%3AIH40-C30D51NUVJQNR63H4.76BRB617566M486KALG617N9%2FQH%24S310D78ZI6EIH%20COYOCHERBZ1VG9OPMDL35*H4F8JBFT6BS7R%241R-9F3%25569K3U58ETB%3A4B%2FODA43%2B7LLUDXSU4I9RL5WE8A5JR9QDJ6Y2N66-J4G28JGB%25186%24CG34%24%25MC%2FOR.V%2BIFZ8WJ6E3SBD-HDOA55O.IIFEVHPBH287%2FEHVNHKT*3U2LMXSV%2BCFWJS*6U*8S738D28Y2B%2B6P%3A%3AOX5HJBQJWOY*I5WQR6DV001AKB0"
+        },
+        {
+          "type": "56919071-faa0-4b65-aa38-42b49db97947:string:VAC",
+          "expiryDateTime": "96746975-17a8-4e05-a281-67e71b63134c:string:2023-06-30T03:31:21.050Z",
+          "vaccineCode": "555b28f0-3739-4420-bfaa-bed4d26bcd8c:string:3339641000133109",
+          "dose": "9a083611-00ff-4465-9bbc-2ffe557ea53b:number:2",
+          "qr": "d505af30-05a3-4de3-b503-f88c7a8b75a7:string:HC1:6BFHZA:9QOJ2SO20KMOGT:6A3R85Z6O-G6+P1+TB58:E9LS4.B9MMI1SBHCM4O7T0ED4W39UYCRFPQ1XGY%V-NHO:UK559.2.ZMQOU7+0HQK./J6A8 62ARFWYQIOHOAP6DVX3EE5ODYV  LC8NN1BOMH*6P1-70075H5M8T87KZ+92XCQ.2P5I1R6X5L: OY/N*/OL*D84KW5NXV09HMHFN+WR6*RUG8L5C$1H+1JN1L491M31LW5O+FUTUKA30V33PNI23%Q8HCL9KH/WEXALYJ953L-D2NVH5*8LV0SQ5N:D$YV754 QL9Z7L100E2$A9$P6.+9CBJB5A$S8M8E9W75V7D-1KY57B1DMDHLOVQS76G$:2M*2ODQ6TQRWCQXQ/M473JWTI .D3%1-JP0-E36S8YGYX9BT2WQ7DZDNZJ9RSXW6CRBN0BG:V2ZIEPK3CVDXB.13VZ1Y M-YT08G0WPNF7CF83T5X-L2.DZF8BK8PBRAK8NN7U.VMJKQMGJGDY NKI1D-T9T93*EEHALQA*5A/311G2U10H30XE3ZCI4FLL*VJ49%0NS1H5IP$FQD+JM5537VO:PZUUO6IF0V1/MQBUUUEFLK/96C521S5.39$A3ABHA7D3%R.FRNUB6Q17OPMGAU*HBN21ZO/VBOTA0D8NLG8847B68LA2AG%12P:Q0897IQVDVOQM4GDOO0NXLHBIP$D$85-XG7C9ZC5H6VVUUUD9PR8571+JA2:LX/QCA4$*0B23089GOSKDBJ%OX72.V1I.R$XSB%SH+CY1SQ:SO+K86E15T3VLUVKVWF.ONMS3D+AZXA IJ5FL0ZTYOBLG6KVL46D9MEUS6ANT*A4+NM%K8RO8A+CDUMG$6VMMVVJ+MNF$VPDR+9K+ZA6$TE4NIFM7ANK92M1F94WR-H-*HNFV0APC16Z4O8*CIWH68P.ZED0GPR7M1V. E 3VOOSJ$1O6O9$DJ4GXVFEAV*CIYTV",
+          "appleCovidCardUrl": "aae809eb-74f8-4ec6-8779-40fc1791163f:string:https://redirect.health.apple.com/EU-DCC/#6BFHZA%3A9QOJ2SO20KMOGT%3A6A3R85Z6O-G6%2BP1%2BTB58%3AE9LS4.B9MMI1SBHCM4O7T0ED4W39UYCRFPQ1XGY%25V-NHO%3AUK559.2.ZMQOU7%2B0HQK.%2FJ6A8%2062ARFWYQIOHOAP6DVX3EE5ODYV%20%20LC8NN1BOMH*6P1-70075H5M8T87KZ%2B92XCQ.2P5I1R6X5L%3A%20OY%2FN*%2FOL*D84KW5NXV09HMHFN%2BWR6*RUG8L5C%241H%2B1JN1L491M31LW5O%2BFUTUKA30V33PNI23%25Q8HCL9KH%2FWEXALYJ953L-D2NVH5*8LV0SQ5N%3AD%24YV754%20QL9Z7L100E2%24A9%24P6.%2B9CBJB5A%24S8M8E9W75V7D-1KY57B1DMDHLOVQS76G%24%3A2M*2ODQ6TQRWCQXQ%2FM473JWTI%20.D3%251-JP0-E36S8YGYX9BT2WQ7DZDNZJ9RSXW6CRBN0BG%3AV2ZIEPK3CVDXB.13VZ1Y%20M-YT08G0WPNF7CF83T5X-L2.DZF8BK8PBRAK8NN7U.VMJKQMGJGDY%20NKI1D-T9T93*EEHALQA*5A%2F311G2U10H30XE3ZCI4FLL*VJ49%250NS1H5IP%24FQD%2BJM5537VO%3APZUUO6IF0V1%2FMQBUUUEFLK%2F96C521S5.39%24A3ABHA7D3%25R.FRNUB6Q17OPMGAU*HBN21ZO%2FVBOTA0D8NLG8847B68LA2AG%2512P%3AQ0897IQVDVOQM4GDOO0NXLHBIP%24D%2485-XG7C9ZC5H6VVUUUD9PR8571%2BJA2%3ALX%2FQCA4%24*0B23089GOSKDBJ%25OX72.V1I.R%24XSB%25SH%2BCY1SQ%3ASO%2BK86E15T3VLUVKVWF.ONMS3D%2BAZXA%20IJ5FL0ZTYOBLG6KVL46D9MEUS6ANT*A4%2BNM%25K8RO8A%2BCDUMG%246VMMVVJ%2BMNF%24VPDR%2B9K%2BZA6%24TE4NIFM7ANK92M1F94WR-H-*HNFV0APC16Z4O8*CIWH68P.ZED0GPR7M1V.%20E%203VOOSJ%241O6O9%24DJ4GXVFEAV*CIYTV"
+        },
+        {
+          "type": "0dabc405-d0f7-491b-805e-b245cc34c68c:string:VAC",
+          "expiryDateTime": "95040fa4-9dc8-4360-9b6b-c5a67e429e0e:string:2023-06-30T03:31:21.050Z",
+          "vaccineCode": "1ffa61dc-7415-44e0-8492-7a427ba92d1e:string:3407851000133103",
+          "dose": "92afd53d-f6ad-40cc-ad43-4f3860e176f5:number:3",
+          "qr": "e2809e9d-b4d1-449a-9c12-27cd52dab9f8:string:HC1:6BFHZAGZ9OJ2SO223NL82XF4 KQ5DD%NF$1QW$DT/6XOJQFDLPQMNJQMLV/5DWMWHE-.C72SB*V7VGZJGSTS %UN.K8OT8-20$3T:Q-T2+%UC55T$U7$8LMKJ.O2J2$$1937$M3.KJ:+3HRF/8L:72MZ7-PFQAWGPCO2VWZN/6FURAMESS/R5:F1CF59B6INAJK3YLA93-5ILNMIBVWR2+31//LNBRMCD.UE*7QQ7H2N8Y+O-O0643$+3Q%BTXST89V9391AI%8R-0.82SY28D0K00UP2TXAQ9HGK0059E68QKODG03VM3:D2/T%86J12668VDOEI01GG$C0372/OVL3U96O2H7N7A/ Q6BVJY1C9RHQDBTHDBHDJ4ZTB 92V-M4W5I%Q2GJ2MMGR637ONZT I189QS:SGR2CFK9TUZUHCWCO/4*MTQ94Y%QW+0BW3B5BRQ5AOND74H BJCFO+70DUX.N9E5C1SSYGD5Q6$CEJQ2Q338MCDAPQVRBSGY07J8-NSW-8EWR99MWPLLZS G4JH6$C0BER$ALBBM.BG:D48B30K815GVDN/8NZ8GZA9Z8BR/TOWG4Y7%XM%%PD%FMX8Z%I$W7RY9%:S. HY-O-JUP3O*KH+P4A7D2$PGHRTXH6Q1MF8KNIOS2 +4IEHVAJTC9UT3.77UH6I52Q1LVE39RSE3I-%3E25W8TQV51$QS G0A1G401HDM%JI/0-HC$G4F7RI.OTV6HNCQ%OH+QBNFKWAR2H000+O8H32DFRC$Q21HBB27DV6X9*527IOY-NBZ51Y7DDP*WUN+L :6ULJ4WPWLIKJBC*TRW4H PF06NY59/KDLD6MDKDJR5QRWUJ002+I4F0RRQ1TC*%6C7W8UMPG3JSVOVN7QU/7H/N3:J4G3O3/5Y0G.$U0PU8.LMCS55K %F:XTH37ZN5Q*MQRC%GB1SMYADSJQC8QIY2T8OGUF%3VGMN8-2N.6Z+9K%5P8OEUQ6005PRB1",
+          "appleCovidCardUrl": "0df0b45c-207f-4a75-bc74-4acdcbc21e24:string:https://redirect.health.apple.com/EU-DCC/#6BFHZAGZ9OJ2SO223NL82XF4%20KQ5DD%25NF%241QW%24DT%2F6XOJQFDLPQMNJQMLV%2F5DWMWHE-.C72SB*V7VGZJGSTS%20%25UN.K8OT8-20%243T%3AQ-T2%2B%25UC55T%24U7%248LMKJ.O2J2%24%241937%24M3.KJ%3A%2B3HRF%2F8L%3A72MZ7-PFQAWGPCO2VWZN%2F6FURAMESS%2FR5%3AF1CF59B6INAJK3YLA93-5ILNMIBVWR2%2B31%2F%2FLNBRMCD.UE*7QQ7H2N8Y%2BO-O0643%24%2B3Q%25BTXST89V9391AI%258R-0.82SY28D0K00UP2TXAQ9HGK0059E68QKODG03VM3%3AD2%2FT%2586J12668VDOEI01GG%24C0372%2FOVL3U96O2H7N7A%2F%20Q6BVJY1C9RHQDBTHDBHDJ4ZTB%2092V-M4W5I%25Q2GJ2MMGR637ONZT%20I189QS%3ASGR2CFK9TUZUHCWCO%2F4*MTQ94Y%25QW%2B0BW3B5BRQ5AOND74H%20BJCFO%2B70DUX.N9E5C1SSYGD5Q6%24CEJQ2Q338MCDAPQVRBSGY07J8-NSW-8EWR99MWPLLZS%20G4JH6%24C0BER%24ALBBM.BG%3AD48B30K815GVDN%2F8NZ8GZA9Z8BR%2FTOWG4Y7%25XM%25%25PD%25FMX8Z%25I%24W7RY9%25%3AS.%20HY-O-JUP3O*KH%2BP4A7D2%24PGHRTXH6Q1MF8KNIOS2%20%2B4IEHVAJTC9UT3.77UH6I52Q1LVE39RSE3I-%253E25W8TQV51%24QS%20G0A1G401HDM%25JI%2F0-HC%24G4F7RI.OTV6HNCQ%25OH%2BQBNFKWAR2H000%2BO8H32DFRC%24Q21HBB27DV6X9*527IOY-NBZ51Y7DDP*WUN%2BL%20%3A6ULJ4WPWLIKJBC*TRW4H%20PF06NY59%2FKDLD6MDKDJR5QRWUJ002%2BI4F0RRQ1TC*%256C7W8UMPG3JSVOVN7QU%2F7H%2FN3%3AJ4G3O3%2F5Y0G.%24U0PU8.LMCS55K%20%25F%3AXTH37ZN5Q*MQRC%25GB1SMYADSJQC8QIY2T8OGUF%253VGMN8-2N.6Z%2B9K%255P8OEUQ6005PRB1"
+        }
+      ]
+    },
+    "logo": "298b0280-2fb6-4579-a8ea-eac49c5eab50:string:data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOAAAAA6CAYAAACpiFWoAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAClySURBVHgB7V0HeBVFu363nJJeSUhC70VBBFF+eheQpoK/YsFesGFBOkFBVEQEVBT1F9uv0gNIDRCaNBUECdITQkgh9SQnp+7O/WY3PSchRO/zeK/n5VmyOzM7beebr83MEXCdiF3Rzgg1946A4Mh+TSLbdFQUn/Z2l5sxNe9EjvXisazCnF2G41c2xMZChRdeePHXYVpc1LjP9vZPSS36ijGWyQqLrMzhZBrsLjvLsiSy/WfeYot39rw4e1Xju+CFF178ebwZ3ybs9bgmW5JylxOpqSxubzq7Z1YcazBkNtv2SxKFMBZ/ycrOWhgroge3O5/tPfMOm7220brYXX1keOGFF3XDvG9NzZYc6JPE2El2IZOxgRO/YrjxUYb24xlixrA1+08wFxHgN4nJbPWZVLbmbBr7LUvnipeytrM3f2x78pWvOkTACy+8qAKxpsgpHwSE+Ubf+POzt21qvOtESzQb9QK279oDhAcCRgOEtk0R3rQxJErr42OGJAjwlQWczUnF5qRsNAwbgAl9VrZTjMZftv8cEgQvvPCiAqolQDKiiH7NIg893+dwyJpDLvS75wnATKRmoFdMRiz8dAaS4+aim5oPlp2N25tEoHmLKFgVFX6yDLfqxLrzGQjwbY+pQ75u8EtO6C544YUXtcOkTY2/c7B97HgyY+j8FEO/iQxdHmcxD81niVy+PLaPsQdHs4yb27DUzu1Y4SP3MXY5maVT1NrzaWwTXRvOX2Fx5zM1cfTQhQ3speXSZ/DCCy9qxmd7TMMOJb2pEY7PsFiGW4kA+7zIMHASu8QDN69gyQaw5HBfdrl9U5bSphG7aAS70qw+Y7/9zNIoyZpzaWxbUgZbezaV7U21aHmt/nUie2ld43/BCy+80OBRBM0ouGFV18ZT8MDifbCdOwPE1AOy8vDl8llo+PsBXBoyFlLrZpBbtITg6wcxIBCmLp3gLChA2p13oH5+Dpo1rg+LzYlA0hVTLHlIswN3dopFiBywHl544YUGqXLAy9/6T5884uNBx8+1wHOvzgRaNgIuX0X7uwfhk2E3IX/4EDgkBik0DFDL+drpXg6vB8f5czBmpqP+iNG45GJQ3S4yzEhIyi9Cm9BQGCTVt/2Q+Ktbv1WPwAsv/uGowAEX7ropuF2z297wk2/Hk59/T5ZOcuEZiEadLkx56A5gywrkHD8JOTqmIvEVgxyAMLZsjaw1q2E4nYjmUUEoondlUYRCRpnEXAXdmj8Oh9ozdsWKMRK88OIfjgoEmH41+ak7b34Oh06r+HXbdqBhJJBtQXjPzhgXY4Zj4SLI9SM9El8pTCaohVYocatBKSGJEsg3jwCjEaezrvIE6N367nopAesnwAsv/uGoQIDRwa2eDDaOwEtfrSN2RgEkOiKvELcPuI2o8zyyTpyEFEaiJ2PV58hF0ego5G/ZBN+iIgREhJNLgmkFMShItgIdGtyOPGuD5+CFF/9wlBLgzFWNhg/uNLZJVj7w0/69RI31SjndLW0aA6dOwmUtJJZ2bclRDA6B7ewZyPROQKABLsqHk6yfQUbi1Tz4mZqiW9vRLWLjorrgz2JMLUTZ2FhRu2qGgD6xco3x+lU5zDPujB2AUVPHY8T022vIr+b6lL/X6y+Uu68K3hdjptTDtTDkORMGx4aiNhj8ygAMn/4o7po6FnfOaoDa1bc24WWozbepXVhN4Tpq/sbXglDruFq2qbQyTHI91Dq8HxasTSaLZy4ZXxoCikJU44OWof7A3vMQOPHVxP1KwHU+WxHElCSEdL4FKar+Dl8pY3EUwI5gdIy+HbuOfTqRgsehrhgxpTuc4g8YNV2BKg/H+tjjVdIMe6YvfsOXUJ0CEcRwrHvzmBY+cnoSmHoB69/sp+c1bQKYcwrunrEHq964t2pZ01ZTl3VB3NxG2jP/kEHu89QhRyjs7tJ0d0zqT327Foo7gDqM+oLaPnaeDVlJL2HnJx9raca+SYqwdVm53HkHXaKrccVChTGIm7OKyl6PX123YuQ0nbiOuqj+03g83bi/hyJNwca5qQgJEXFF+BEjp9aD8WwLrFypVGnHvdO/hIXdi0DWi54OojqMe/tF2Ivmw+WWIVD13DReVMpuzOub6eYprIy9VNY300dQmg/oLhoeDHuEIhgNIfSOs0rMyOl346hzIUbNHI91r+/wEP8t/d8D+XJrJMTaMSI2mpq9n8J4X/jBEwRhHtbNmVolfPSUFVBcPTFqxhSse2N51bKmHaX/3fQ9b6kSN2rKWqjiqHJklkcXsatK3yxuroARMzpRm9bT+JyA9fOqWv1HT/0YqjCUjyWNALlBpCAie4DT3Qzvb/4BCA7QCU0hDhjghwiyeiLlEgSTGbUFN8ggKxP+WocUh4EvpJFwiard1LcDIiPaDCEXvUB0WQuq9gBRCKQ3Y7S3RcdD9P/LVdIofvdRZRpqlVDVsg8mUscpCCx9FoT6lCQaTvZvDJr8Kba9tbNSTu3palgxiHFiLCp9HBXbBIIaT0R3ler0POyWVAiGRpT3mwiKWErx6VgXuw5u62kq8HtKw2uu0ODleXeisJ8p5A/wQSzwf8JFvW7gXJQIQfgGmjRPH0egv6raAoL8AKXuRdyvOZYtc+GB2PdQoH6HwhZf0jv3V6juHRNupmHzICS2Fz/Mrp74etw/i2oVS3W/CsH5DtXvOFQpiN67h8zad8ElnECbrs3wx+FsvS/FemBKQ6rTGbpO6nUs6VdGX1fIxdXqtqexCErUgCbDkGri29J/jWgg6Xkyt4nKoH5GLl3bKpSlg/pOrToRj5gaSRPVGOICRGKO5ylkuYfCbkJ1YFI8lWcv983uBCc+QVhDIRRO7YSgT3iC2kBrExDuOS+hNYrHkkaA6SE7bhncanrQhbRAXD79OxGgv56QE2BgIHxtJHpeSYNgrj0BalywsFDrHYnuea05HZpJr7xksaBlUD00CLgx5L8Hkmm2ST+MOkFUNLI2GBgRzgh4IkCzaSR9XL10qdwg0Ek+s+xZdVFn0sCm6cDPyAdvJWJDFl2tquTPtPDie+csMGpxrhxNs7W7XKrPMWoagyyv1SqyZu4e+runNHbklJ7Ulj00Kz6DDW94cs8Q8eFXmtUfqBIz+rV5UAyT4Wg9jJ7W4+vY74kjjYaveRxuGDAXv8efKsslZAWZpIGIzP6oDg8u7krfPRaXfzuI3V90qxS7EkMn3wXZtApd7lxDBNi7uOEO/Y8wkeq4CdcDgRWBj12RBrFn6ETuk69/MeZSiofth1g7dwZqC1l8QhvPEImDi0Mw8PmW2L74bKVU/Fu6Pb4fN+dDrcwSjJxOmbEHqb1Vt92Jop+mvomCzWNeYDklXEmbPVLyfPq1Cr8VP5+j8nMLdOOLlg7avchFDyf1sXgdngPO1pSqEhAXQ/PtBeBfrEODvjif7eyBOkOVNE59NXUVJLkFOo9pVCF69PQ7iLBIVBG/0JOLNcjwYoDeJ85nSXRsgP6PzcX1wke8gSxOqER8xRCmwu2M8/geE2L0JKxhNTkr9C1MHmMEn5Xg84rIOpSGmULHw0STaKOO35eGjZ76CFxoDoP7RY1TVofctA/hLOT5DvQYv+kt8jG5jiC/qBd6PqaXWWIXENS673oRqiVAxXMwu77F/bJEInVBInKlETBQVwaFvYw/BVWXnobMCqwaxfTvr6oOz++KpeNDI8Aw/+BRIK6+9+RpjXOVpaMRabPDyUXPoGDA5UTt66dCJJcEp2GmSUxl4Pc51N1RoR1p7gy+DXWFyhUs+vhm4VtIbgdxu4pEozqmQjKTWCR9r80molqzqKvQ7BD39oeQbVvg03gqxnno3JrgkPZoOt+wSXMwanKTCnHr5pBeMneUx/eYUDwdsuomCC6Sev6Y7oK+EA30151QGrbyJRsyjr0Gv7AOeOzNnlqYTf0cPqZUrHxzEarDE08YiEt3gTXnDyR8VFhtOrc6jy/Ih+gcoAeI2oRL/ZeLukKpNsZznzDBitqi7yOtSWwOhdFvsTY5MtLdXI4H8VfA317DpF4NwxLUUiKT52/t4BfuH30TF1cPnCffn185MVOidPmFsBh8SCBrCGa343rAraF8qlUrjXvumM8izalNQAzCwxoNjF1hNsaOTbwO6i5tCCPjC4lUwUfhsH+A+jfwWa1MTHOzbmC212hwZsLI2+WuIS+aJZTiejYKuxvJ7kK4CjbQky5mcenlWgJAkWUufPyGQzJMI/Y/jYxDl2hQLifdaRcRYALqDgsNmjAyrgzW60pULtHs6ChoSfWaC0ldgY1v76vwxo6v38HIORORmvdfDHxuBbge70gbXWMpmdExmvTjyj1QYzpVPgY+yRsDm2rPzKVqkoiA90g0exUlPSVoxEP36uOlxq+qKP4obAsZm5Tid0rAPwhROnIqvcPDH6OyehO3KfdVBK7/FSLIOQxfv1tGoCHhszXJZMO8T/T6gwxg7FX0erYp9nxwEX81BLh1nYutIMOOAlRqk6q1SZvgRJvL2aZpREvD5SwFJ88nkdHFtywpJ8DCIqTa3DoBcjFUuLZVmX8M0UhsPrK+Ziaq/IoscjG0CLIhGIHmBsGh4ba2qCu4GpjvY4TTZylxA27p0vW0oa/dCCNNHGr2f8jy41urvLh+NDo2Au++akX2HwvgDuiF0TM66nGC4Zrvb12YQ4TWmnTx8fSUQIOjEXHdmdQhu4h4UnHH1JtRFwg4B83aJmzRLsa2knVyC+SAJZB9TJCdr3p8T80ZDaOxAYIjXyLDw1Js+Kjm5X/M4QsnzYwBYTVzF8nNNAu50azP5HyG1b4xa0aW0u4k9t+mXap6K11dyPhRg7hYMjoYGRlAVuUqFzdyeTLpc4f0LRTTufSSyJAlkCEly1FxqlSMZDyyxZc+G/NnaTRRL/Jp/G+AlUoy3MZwAVXbxIlPd0O4YG3ZpF5zHDtTADU9g8uFZRnxvrE7cfIKTUCt20Dr5VrYK5nLBZmMN0qzVuCqs0Gs2H9cDyyiDy3CF2G+MciyOltS8G+oKyQlBmvn7CZDBw0GAxctpsNkngHBwbBxWRaZuAdqJvRrcTDeJX4GPdXOL1/B6JkT4FbW0RPN9EJWrRrPE62dy404X2LMRB84/WkAinfTzPw8ZHUvxsRGkjm+ENcDBt4/SeAuG6YKGgck86c+4LEULkMCWUFbVnE7bHjvIO6asRl22xCYol67ZjlGUw7o28GlXMOXKDeBgSbxjDMp2qNkIvMWF2DU8cRlvsT1NU7SDWTkclkzt6plduS0jfT/sEqh1AdsEXHVF3Et9J/QCqLM1ZFO5EqI1/QqFwm8PExxPkMpJuGvhkhWIs3uRxPxure2VYkfOe0bFLvfZMnJmgT5RSAtx6mt+awicZsMSPiVDGnjboZ/RAQcDju5I0zVF07EpWSkI2jAIDibt0B+egERYMVMRU6ALjfsNIzqBURh9xmxCf4MFBZWXPiv9PAIOAEqyhhSQv+rBTNSmGvBuDUxymIts5SqzuE0KLdj8NPDiDP8AZPfkGrf1f2CsVTWbvItbtfCVi7kVrC92jXyFZoNfebA5ryVnnfg+kB+IeKCcXN/qhS+h8Swf1G9H4c1gpu9k6u8qSgpmi6fb7Nds5SV5CYZToZFSe1XYzqRPaYZ5YIa6GKv4tL7ThLdqCtUybMbQiBxzeO8x2o1GxJhz9BcD6LfFTjdnXQ9m9ngsiWRvtsEXe7rip//W0crfDVQueNU840Fe4wXmYnS6Lc0m0b7yjFIzS6Abq6vhLBA7N20B6k+4QgfOgjuK6kVDTWVIZD7Ic8C/+GjSHEh+SE/XyO4ylCorCL6XL7GcBhlZwz+DIRiEUURp9N9FIZPeUVT2lS3LvNLqlKXbBH3VjxJ84nEzjeSoaMX9U/1olkfXiCbRoPwC4/xongYXBeWZSOuH7z+nt8TOdFxAiv09xjPmO77rGf27LSuDJOD+yfr4Y5p1VunVZq9fYOzsWWBToAl3cuE6/BTVYKgepZPWDVTJ3cZXQtjVkgIjLofhRk7sDq2AzbMCaNJLBRxb8aQZNdfq3fzmx4pTa9yHxL7C4/TFKprUykBiT4+/hFGkrAOnyVpIiNXFzvLE4yvGex0Mt49RLrq5CmkNNr0FTKeQISpkvPdp1kT0sGG45JTpfFWkVgF6HNDETnqOQH6GMi/K/lE4s+AKXqnmW8gx6xEFM/mU2WysH6u7murG/npMLoHkR5FRGzoTIM5tdp0sbFUB+VHKisGI2f0rBDXZ7wZqvl9reU28RD+SihEDrxTw6Ic+CuQcfV5csDTEBH3Yvi0ihbqMa8FYfAzP8FAxuGDG8oMOoa6zCl/EiqqK7RsyaD79zuI01G3By+skmrH+xfom5I/LP+x0jBJUj0TDauN/FQnyJLgG+ZwGzBpVDsSF3vipz2kigXRZBpZLBFwh2J0OJYt+hbzV0xHg/EP4OKnX8GnSydN1yuFZoZW4LqYhgb/+QQ5/oFIOZcOf4O+2o23gFOJlURP7pjv37ohoog2T+X6EREKIXWrvhigDWrJoCv5K8cqGPryYZhDSOe7WibmCVKoNrG5hDJjjN6lrctlFqW3V6i4VnDl3FRyKcymriLFvZwjvtUVARn1eD7NS8MU83jykZGFkETDOyb9Sn7T08Tew+FSB2qTgNn9FE0KOVWaIajBmp1BFaszVkiV6lquC0ic4hJJfj6fyad6SFHsG7XXzom794urGD59AOmrO6gvDpC+kqStcGEsAC65G8zU5Urq87i4e2/pO8ytfz9Vrd360vJgYoj2DVXVs8uHkZ7Lx1a+pM/kssGgS5/CBKqb5x01DFupn2+HQfkMZAZA4NktntMJn5B4+gp6PP0E9i1dRt9LImd9OOVbkbv6E/0m3X8Q+78pW5ggkNqk1cOnar8KCNLFZtWzCFpu+RoZJOV6heRe6NOxCfYvnYhlcfsxf9VunDt+Xl8RE0ZjIiwARb+fwb+/3Y9VH3yJkP37YTmVCEOr1sWiuKDpAY5jpxA+/j7goSfwW45V00RFEkl5EqtL0frxhugwtPA14WRSBvZdLsK/2gdRW4wBqAtE5ThZ2BbAKZZZ90KcM5HnOg4p4NOyhGoCdfYCmjPPlQYp4gIavOVWwrDvqIJpNBvkVyln3VuzSdfypTRlImh0tIJ09wJqepkZe2NsFkZMaksEv4icvXfTR7gZdnKeitx6aZiLVZVcBWWFH6SBSBxS+dlzvPA2lZ3pMcpm2AizKwbB9fM9vyoupXocwtVyS+auhQ1zduLOWQ3JX/w6fcJR9P4gyoh8UGwzuXTmIG5xRV3Uqe6nwfs+WXx343rBGBEytd0keXZTiNLbJBq2QhNLsZtKzqZ+epcmVBqcAh/glUVRrpDo9SvC9zAIyR7XxHK4XW9SvwsIi8wpfqYJTOSDuqJExtMoOFGpmEVU9xs99qsq03hU3qf3PC/3E4QlVI6+iGHJjp7JRY40diSTsW0p+oGeCl1LV+9hQcMmM7R7iGHgy4x8Wgyt72dLTqRpaWx9OrMk8rMnBRtYUoDEkkhVLnrmES3u50InW/NHCotPzmTrzl1hq8+msnNWhxaXk29lL3+0nqHteNb++TUUcpa9veWGagaeF178/4YsSUazIBhhIgafV2THmnNX0Cw0EE/d2RNjBnbGhyt3Y9Y327VjKdA0Gs+Nj8XlmY9j3vYDaLxvC5w79qCIROTg3n1gHzgUR4pUpKRmwt9kRC65MFrVC0KHEH+k5lgQ+90OLPzxICwX07XlS62igzSPpSxK3tOzvfhHQha0ZVCCtgjEh8RsE18snVuA89kW3Eji4sxHhmBU7w4YPvlTXEpK03TDt6cswZrd3fHo2Nvx8BvDwRcA8iX8yekWWC0F8DPKsJB+2KtpfUSQW20REfG0b+NhJeJGFHkMWkQDV7LJxaZWWSXjhRf/JIgqc9tV1a25ikpIwYeIMIiIKDEtB2vPp6FD8xhc+GEWGjQjb8FVUjXaN8HZn45h8qgXsf9goraW6HDiJahkIQ00G5DncGNYyxiEkQX05iffw4szl8NaSCpEO9I9A32hmeP5LnkyHnDyV5lSd/+RF178H4boVl25DE5tFVZ5XsTv/Yl7mYlIVpxJ1TYSnFo+GTI3zBD3QgQZr5rU14iVI5AI1kAcNNvmRK/GETCStbPl/fNw9OApjWA1g46iViiAE30x4f81JnQvvPg/BlFRnVf5Vji+AKuyNKhvoBU04lp39gr8fYxYMYes3QVk+HErmuuhxGXI/1idbjQnx30UccFuUz/HxaNkdGzdSLeUVl64QG6BQB8fKrOQsnIVwAsv/oGQ7Yo126UUku4H7fSyytC2BBKVmYm7JVzJweiubTFwdE9sX0sWdX+fCun42S9dwgPxxY6jOLKJ/M1tG3l22nOqJWIN8fej2wK4VXvdt7EUY9nerq3ATFFFeerFF0fsv1ShDQzC7NkQ+I+Gavcr2xk87b7gP6U2q0+CUnmH/ryNPZqZJTTykXxSnxq0/WxN9fjk586GJ7v84qpc/rJfOsvGggAp1+QQ/LLChCdHbKzWLfDOjn7NzXA3F0Qx57m+CVUsxPwEg3T/QtkdnCf6ZTmFNLvNXbk9JWU6MiMqrIQI8LEJybsTnN4fUP17QHTYCzJziy4SlyM5kEREm1upsvZHczeSjJpu0cfM7Hv66rJjOZHS5ibia1APdocTj3ywVnfkV16Cptt7SITNAjLz0JTEWIZCcpW5M/AnsGR77x+LHObTNqeQIPiKyQu2915bPv79+N5fhvTopTmOF8V3bxgcFnppaXyf5eXTfLJ9QFCIol6at2Xg8PLhs9YPPmQyyudFg7jLITrOzIwbeurnpMZRnuqxYHv3xS6LX+p3+7pHlw9fuLPnLfY8v0sWRbVKRYYim4/F+sGuPuzDvT3mlU/30beNQpYeuv1XWVHPcWeyqqhHFsX3ci/Z0b10DSonviuhGQeZ0ZrD87L7+llDQsMdS3b1urJsZ7feJekW7+j1oC3P7zKls5e/qA426osH4MXfAiIT3VeSss8jmDjgvW0aoE39UOQTd+LEWJ5+OHMMNBnwS04hurZtjBCu1+Xri/p5MgcRblNfI+IOkT30AllLyZVRKnbyjPhqDb7UjSyhvbq1x+rvpuLxgQ1w5MJZclkoV1BHLNrZ6xsmsKGSIvdXJbGpapDvcjNp1Lc/3ZZQWncwvoJF21akygajoIqRFrf40Of7u5aubMgWGHeFREli2dkkn+zu/lt9f2tno6yMUiSxpSgIQ8P8ipoePN/woqcfHpVFw/1uRah3Ns80tny4wLTDiurT3auCINwnSdI4e4H1dXuBOvmDPf1nl6SzBjQ4ITiLOvmaXHeRYaoxMbGukIRNiipvWrq3Rx+eJhEn+dLiLtSzu6h7x6mUH/XvI2RHu1ToNiW8t6VPC55OFFhnShdBjvinydL9DOU1gV8U9SwTlYPw4m8BuWGoPSkoQMWWX9Kx76cDeIHcDne1jMa+9FyN4wWZyrbBcX0widwTnUP98XCfm/DezqNaOOeD3O/H8d2+37XfDiwFJzy+yyI5A81uao63HhiIMf3LtsWl51yCydd4EXWEqgrjDIIw+dnBO0sOUUp678db5mQW+E8vbaRRzGEuVVtJIiuKkREzJ2HUn3wwqyhIWwhudsuMb87yNbq0Xcevrx72jMVe1CE6Kit0XIcTJSLyuQ933dLE5vJLM1sFvkWm9IiJ5Qe6TMwvYFdp5MeF+Lr5xuD3K9f1hQG73yv/vGhbtz5Ou5sfbzbroyNDphbkKTFuhxL+7IA92cVJuCg94u0NA9J8zM7V4HvgEhPdavfefC3y2hcH7vlvuey+eD++F19NzM8oeRtM4FtWcl7on/AxvPjbQrS7Q866iAFFhvhg7vtxaHnnTKza8St61A9BR/ID5jlcpQcqaSjmaoM60URrkEkKZZobonFYAFLzCrHh6FltB0Xx9hSg0EYkkY7HHxyI88tf04hvZ2o2NlzIL9Yb03A1zXgOdYRb4ftL1HuWbv1X6XkkLw07MiPfYSm3+r9suZ6iSkbiDr4Bfs6hmdaQ6AXrhhfvk7MUxwuaXB0aaHnJaBJOlSM+DRP6Hkl/ZVCCYLdnbC4fnlkQ+LIksn0vDkh4mPJo8MGWntfcfOtmvoLR6NLyt2W654b5WzY9O2BHduV0kcGW1xwuQ+hXWzv4cd2Nnxslsop6KhdNuVbgVGVNmmCidn7X/9oiYi/+GsjZMP9x5sop94PdfOV2I/shcVM8xjy7CPf8uy++nzUeQc2ikEAiZTBxQv41+XES/EDECH50YbAfXKT7cTNLRIAvks5fhppToO+q58SXW6gdbf/ZW4/j0SFd8UeBDb+n8fHG0CosBg6XBfm2FEvr+u5TqCO6NLvYb2di211hvtaMRTt6ZbgFaaMomOZM7LslqSSN6nKVjkSB7L6QDIHP9Ni1953vbnxYign5goLftgw+kOe3rR8ZoxSNAyqS1ByF1v+U5LF4Z9+Oqqp0IeJV4GJHKVPOtTXDx/ytg/yMoj1GNYCfjUmSglrkksFP/n6YP4uQ7FxOWBTfcwpjYpYo8p1LQg+nm/UMM9u0s0mcBhXMpu731EbVZN7ltknIyjfxXRZbBAlWKMK9i3b0CRVUJtBzSK5w+U6aZj4vHLznW62dDOf4AqXF23ufZWXHPPCDKbJEp2+P54du9rp+/gYQY/smFqbkXT5OHnZ0a9pMPxOGnOg/fLcTnR6bjwgyvvRtWl/z7/GvqO3tdCoI4unICup0uzUR1NcgItdi08VNnshKY45E2K8WPKUR3z4ivN/JsR9M5la+PzDcjzPHy7A4Urc/3Dfp+g6bKYe+LZMSosPzI0l0fJXc+X+YVOejkmK9uDihTLeqDL576aN9HVpPuvfEcsHgj/9sajc/ltgoaYdEF0wz2wo0gbjdjtJNrIwJvWhKmUWRU0nXPAaz8d2SOD8mjOUjXnUJ8me7u3XyNTrOqapYelgvX+yg3wnPkeg4lYhwpkuRBgUFFLxy721Hv+YWSzO9X+CUPRJFRprLJMsqfIMCNCsYU1UrsbebqVKPUamPKW51fGZhYOtAX8dp3g6epsCunSFJ06N6hDH1ML+odYfo+tUUkem1gP5NoBkSZPFKnIqUm3u1a43PyQCjHTPXrgmO7TuBTk8vxNGlE3ETiaR/XM2HkQjSRUTHz/fkB/hwEZTLQlzIs/HtSWqxh53EzslTx+GBvjchPiULFrsTIWZDsUuQ0T2QknMMObbCOhsEXvyiT3BopE/Tp7tv5srou8UXvj78r0/TctSZ723otuyl4QdS+WmKrJw3hCkMRj9ffmjqaUd66mCXud7Wxdu7ryYKyqTKaVuWBKc7Xw4IubHknRf671xCf/iFxdt6HXZCaloS5zIWjVe184DU7YVOg49bNVtVyP6bf2vaekjHi6cdijnIR3bCJYkdXumbkFW5HdztsWSbArfR0MFTO40GNpCfGZVuVLVV/ppxhYwppFOWnlO5cFfPx/IK/T/9/lDXuH/feviMWXbxbUgFLw7cex+8+NtC8xEVFBjjz2T9jK6t6umnYnMnO98HSJbOY5sPYeIXm9GWxE25mOD4ENAUkHJaiH5bvJmXdLw2vTti3rj++I2sppz4gojz8VfdNJCCzP7gHsTEtAQYFfM+1BGtGkqNgkwFv76/uWeFgWtKinnKQMKWj2Ruwp+rTPfalk1B89VNGv3bNlFyJwoG43b+6zGKqOuAgmrYSJTay1O5xMFvYqqgbc5dcbhdfRIHe1mzcL+qGm5WZbG90cg6GI0qMtPNmptBlrVTk2leU6o92CnT5rfZANXjUXmBQfIUG5Ss2L4JbtIBtVOOheKJogRGSBu5Vyg5L0Dba2aQ3YpXB/z7Q+OAA8JbHf714uqCUR0fCohq1Q5pZ07qhhROMW0a4f2l6/EwEVTfxvWx/kxqzb+Kwd8hLvrZc/qG6ZPkeojwNZWusrHTuGhTL4i4aDYu5hzPF04k1fk8jsx9O34P7taD79GMi13RrnWJMzo78soG5iCCL9QPeqJ68eMatM2uZLKRODlYi8p+F8NkMPRnKtJo/PpLTD8ujgniJKrzuAXxPbapiu/oVwdvsy7Z1j2atMmVChSDySBpnOxsdqPp9cx5eGHMwW/L123rqXarD59vThbJUzAJdofKzxB2MJ/q2jLyhj/uPXIpJu/zvbcet7t9Bk3om5DORdPPD972IYm2DUMcZs1lEtp1iIGRCkhRFY6YUJ2qj0AOCj/JoR3Yw/TDHEIW7uh5M+mtAlP1Da002UiqYr744oAdf8r36sVfA+2j9KWZ9Xx64g5fYxKeHzKQjCeW4kWaTNcJC4rw1qo9NDr13RJqTefhkCU0kiyk3ds2wrE8q+Y7LEnNCZSvlmlMtJ2ZfxQ51qStf2ZFBn/XBPlGl+gICQ4Nc5DT+jIZJmwup9iPbLPDJoxN0IhJUAVuN8oqrgM32jr8zfbSlSN8sCsuZToNUyfpehpnfG7Q9ismWR1oFjHQINoLF8X3zlYlKVmSxYvEyt5xOfUzTEKNeaNdgnFD5bqlnClc6Gsuwgfx/cNUtyGFH6xrFI3VHo7RpfmFfMbcfS7nBDZzKSyN2lL4wa5eak6e/LQ1H2MeHxqvieo5jZJ5dzroy1U4WS0yJusq6Zd2typp1ldqB82i4DbiQ1BFrvsd4BdTpAOi4LwXXvwtULpMyaKKX13Iiccj/ckQExrEPet6BJdrIkOw5fh54l5uNAwJICKqgQDJ8DK0YzPt9kJWvraErQQKEa6/wQ8+RAUn0reBWbEQfxJPD074fWK//cEyM0wUBWmNorin58iS/8uD9pf+RgGJlQ+S/tWd32fL4inByRo+0ulohR3YLwzeM9flVhoKTt/S3d7P9N0XXy8rSlYE4QVRVT8h2/7wF/rtuf+Ffrtfs5w6PounYUa/nhP67BlRuV6Pjby032B0RQiS4niB6igYWcOI7LDLNTQFz/Q7sHvWyO3+kiQ/RvPfUiYaJ8kFiu/E4XtXlaSZ1T7Rxetvtlo/Kv/u2BsSC2FgjRRm4lZd0mH9PpMdYgOa3trR1VZxi234RfetFFFaDi/+fvhoZ+9kvmv9lkk/MNxEBrbR05l2PsaQ17Rd8SeTM1gKTc/H86zs0tU8hp7Ps+8SjrE8eofvpV+573eG6LHsvXX7td3vq85cZtuSMrRrO12r6flCAWMFtiQ2Z0Or8/DCi384KizUPZd5bpnF+SPee3C0ftRcyVpPvprF7iLp0gY/soJWJzPyowZBls5GpONpJ7mXW8umnVNKlsKmpI2dydyMooK0j+CFF/9wVCDAoR0tH6/9ZRF6tDegw4B+wOVMXRfUVHp+/L9as1lNO4tU1PYFlld2+DuF5B9sGcot/27sPr0i2yg3XAIvvPiHowIBDmhbkH0i5fgcmzsBHz9+P1Dk0Fy5GrS9f7X4JU3+GydqRULlx10IgowbQmX8cnEZeTh+eaNOP8bihRf/z1DliOsF92TM+Orgc65ubYAxj44nO/ulst8LrEsBRLS5Dge6xkQScRZhyx8f5hcOtni5nxdewPOvzuBqbtrYXy6/jxWv9IPUsLEuitaBCLkKWECiZ5R/EGLIA7bl+HQ47DkjS5ZLeeHFPx0eCXDGiOx1G0+9t8aNI/hp6RxySajaompZEmudMRdBtc29JHr2jgnEhcz12Jmx4ps37kzfDS+88EJD9RSVl3Lv/B2PpHRtDvxn8Tziglm4mm/FtX8kT7fbcG+2UxExrHkErEoSlu9/MnH+4FTvTmwvvCiHagkwdiycuad/7/rhnh7Wh/uG4cuVnxNhSciwOWFXqlpD9Z0S9H+OBdmF+uL/Me1i4HSex9Jd91wNsgf2hhdeeFEBNcqU8ycg3ZJ/ocsn+7unP9ivAENuaQV/GBHlY9LWdPJlZy5F0SyjXKnLJA4pN41GmwZNwffC5OX+hA/3DrwQZUm9+ZX7zmTBCy+8uH68va1h9Oz1bXcduPgxY0z/jYd8K2Phw2ezH3YnsgJ6TsxTWGYuYxYn09IknF7IZqxvtXn+1sja/S6dF154UTOmrAh99KOEwRl7zn7AcoqSWJ7VxpwujR5ZocPOnMoVdjpzOftoV/8rU9dG3Q8vvPCiRlz3frH5Wzv4FRXljvD3jRrQon6r9kBQOD+K0ObKu5pvO3M8pyBjR5jJP+75oee8Rx544cU18D+qbo3I0X6DowAAAABJRU5ErkJggg==\n"
+  },
+  "signature": {
+    "type": "SHA3MerkleProof",
+    "targetHash": "e76330379cc74fe7afef563e591ad1244792e34ebc8b305ea03a8fb23b104f01",
+    "proof": [],
+    "merkleRoot": "e76330379cc74fe7afef563e591ad1244792e34ebc8b305ea03a8fb23b104f01"
+  },
+  "proof": [
+    {
+      "type": "OpenAttestationSignature2018",
+      "created": "2022-06-30T03:31:28.668Z",
+      "proofPurpose": "assertionMethod",
+      "verificationMethod": "did:ethr:0xfe0e8e2bea0068d4bdb1df5ce0d4fec585546c17#controller",
+      "signature": "0x0e029d4b0af4a449f6b9ed6fdc0398364984c3d4e085f1405faddf40a6546a5c74838c4822cea733c36e79e3c02efff1bbc620e964f25ffcf2f59f490438a8811c"
+    }
+  ]
+}


### PR DESCRIPTION
## Context

- `Document has been revoked` message has been shown too loosely (e.g. A document issued with a Mainnet document store (i.e. revocation store) will show as revoked if verification is performed against the Goerli network)
- In such cases, the message should just show: `Document has not been issued`

## What does this PR do?

- Perform stricter checks on `isRevoked()` function instead of relying on `revokedOnAny` field (since `oa-verify` treats an unfound revocation store as revoked)
- This is achieved by:
   1. Filtering for all invalid fragments
   2. Extracting the document status fragment (either Ethereum document store issued or DID signed)
   3. Checking the message for "has been revoked" text (ideal method not possible as explained in code comment)

## Try it out
1. [Ethereum-issued but revoked on Document Store sample](https://github.com/Open-Attestation/verify.gov.sg/blob/4df986e96e36b8461220e0f20382fcb50ee93350/utils/fixtures/vac_v1_healthcert_eth_revoked.json):
   1. [Mainnet verifier](https://deploy-preview-160--verify-gov-sg.netlify.app/verify): Should show "Document has been revoked"
   2. [Goerli verifier](https://deploy-preview-160--ropsten-verify-gov-sg.netlify.app/verify): Should show "Document has not been issued"
3. [DID-signed but revoked on OCSP Responder sample](https://github.com/Open-Attestation/verify.gov.sg/blob/4df986e96e36b8461220e0f20382fcb50ee93350/utils/fixtures/pdt_v2_healthcert_ocsp_revoked.json):
   1. [Mainnet](https://deploy-preview-160--verify-gov-sg.netlify.app/verify) / [Goerli verifier](https://deploy-preview-160--ropsten-verify-gov-sg.netlify.app/verify): Should show "Document has been revoked"