### PR TITLE
fix: remove download button and add react hook dependencies

### DIFF
--- a/components/figure/Renderer.tsx
+++ b/components/figure/Renderer.tsx
@@ -12,7 +12,7 @@ import {
   Template,
 } from "@govtechsg/decentralized-renderer-react-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faPrint, faFileArrowDown } from "@fortawesome/free-solid-svg-icons";
+import { faPrint } from "@fortawesome/free-solid-svg-icons";
 
 import { getTemplateUrl } from "@utils/oa-details";
 import { OpenAttestationDocument, WrappedDocument } from "@govtechsg/open-attestation";
@@ -50,14 +50,6 @@ const Renderer: React.FC<RendererProps> = ({ document, rawDocument }) => {
     }
   }, []);
 
-  const handleDownload = useCallback(() => {
-    const a = window.document.createElement("a");
-    a.href = `data:text/json;charset=utf-8,${encodeURIComponent(JSON.stringify(rawDocument, null, 2))}`;
-    a.download = `document.oa`;
-    a.click();
-    a.remove();
-  }, [rawDocument]);
-
   const handlePrint = useCallback(() => {
     if (
       navigator.userAgent.includes("SamsungBrowser") ||
@@ -94,14 +86,6 @@ const Renderer: React.FC<RendererProps> = ({ document, rawDocument }) => {
           ))}
         </ul>
         <div className="ml-auto flex gap-2">
-          <button
-            className="w-14 h-14 my-2 p-4 rounded-lg shadow-lg bg-white print:ring-8 print:ring-orange-500 text-primary hover:bg-primary hover:text-white transition-colors"
-            title="Download document"
-            aria-label="document-utility-download-button"
-            onClick={handleDownload}
-          >
-            <FontAwesomeIcon icon={faFileArrowDown} className="text-xl" />
-          </button>
           <button
             className="w-14 h-14 my-2 p-4 rounded-lg shadow-lg bg-white print:ring-8 print:ring-orange-500 text-primary hover:bg-primary hover:text-white transition-colors"
             title="Print document"

--- a/components/figure/Renderer.tsx
+++ b/components/figure/Renderer.tsx
@@ -39,7 +39,7 @@ const Renderer: React.FC<RendererProps> = ({ document, rawDocument }) => {
       toFrame(renderDocument({ document, rawDocument }));
       setToFrame(() => toFrame);
     },
-    [document]
+    [document, rawDocument]
   );
 
   const fromFrame = useCallback((action: FrameActions) => {

--- a/pages/verify.tsx
+++ b/pages/verify.tsx
@@ -82,7 +82,7 @@ const Verify: NextPage<InferGetServerSidePropsType<typeof getServerSideProps>> =
         dispatch({ type: "STATUS_MESSAGE", status: verifyErrorHandler(e) });
       }
     })();
-  }, [router]);
+  }, [router, props.universalActionType]);
 
   const handleDocumentDropped = useCallback((wrappedDocument) => {
     dispatch({ type: "VERIFY_DOCUMENT", document: wrappedDocument });


### PR DESCRIPTION
## What does this PR do?
- Remove download button (accidentally added in #139)
- Add missing dependencies in React `useEffect()` or `useCallback()` hooks