### PR TITLE
ci: commitlint ignore Dependabot's commit messages

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   extends: ["@commitlint/config-conventional"],
+  ignores: [(msg) => /Signed-off-by: dependabot\[bot\]/m.test(msg)],
 };


### PR DESCRIPTION
## Problem

Build fails because Commitlint says:

```text
✖   body's lines must not be longer than 100 characters [body-max-line-length]
```
- https://github.com/Open-Attestation/verify.gov.sg/pull/161
- https://circleci.com/gh/Open-Attestation/verify.gov.sg/14616

## Solution

Add to Commitlint ignore when commit message is signed off by Dependabot:

```javascript
// commitlint.config.js
module.exports = {
  ...,
  ignores: [(msg) => /Signed-off-by: dependabot\[bot\]/m.test(msg)],
};
```

Referencing from: https://github.com/dependabot/dependabot-core/issues/2445#issuecomment-949633412