### PR TITLE
fix: qr camera scanner does not automatically start for some devices

### DIFF
--- a/components/verify/CameraScanner.tsx
+++ b/components/verify/CameraScanner.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from "react";
-import { QrReader } from "react-qr-reader";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Html5Qrcode, Html5QrcodeSupportedFormats } from "html5-qrcode";
+import { CameraDevice } from "html5-qrcode/camera/core";
 import debounce from "lodash/debounce";
 
 import Heading from "@components/text/Heading";
@@ -7,14 +8,17 @@ import { useWindowFocus } from "@utils/window-focus-hook";
 
 const FIVE_MINUTES = 5 * 60 * 1000;
 
+export type CustomMediaDeviceInfo = { device: CameraDevice; prettyLabel: string };
+
 interface CameraScannerProps {
-  constraints: MediaTrackConstraints;
+  cameraDevice: CustomMediaDeviceInfo;
   onResult: (url: string) => void;
 }
 
-export const CameraScanner: React.FC<CameraScannerProps> = ({ constraints, onResult }) => {
+export const CameraScanner: React.FC<CameraScannerProps> = ({ cameraDevice, onResult }) => {
   const isWindowFocused = useWindowFocus();
   const [isAwake, setIsAwake] = useState(true);
+  const html5QrCodeRef = useRef<HTMLDivElement>(null);
 
   const onResultDebounced = debounce(onResult, 2000, { leading: true, trailing: false }); // Execute on leading edge (first call)
   const scheduleSleepDebounced = debounce(() => setIsAwake(false), FIVE_MINUTES, { leading: false, trailing: true }); // Execute on trailing edge (last call)
@@ -27,35 +31,74 @@ export const CameraScanner: React.FC<CameraScannerProps> = ({ constraints, onRes
     scheduleSleepDebounced();
   };
 
+  /**
+   * Cancel scheduled sleep
+   */
+  const cancelWakeCameraAndScheduleSleep = () => {
+    scheduleSleepDebounced.cancel();
+  };
+
+  /* Initialise QR scanner when html5QrCodeRef is available, camera is awake and window is in focus */
+  useEffect(() => {
+    if (!html5QrCodeRef.current || !isAwake || !isWindowFocused) return;
+
+    const html5QrCode = new Html5Qrcode(html5QrCodeRef.current.id, {
+      formatsToSupport: [Html5QrcodeSupportedFormats["QR_CODE"]],
+      verbose: false,
+    });
+
+    const isStarted = html5QrCode
+      .start(
+        cameraDevice.device.id,
+        {
+          fps: 10, // Scans for presence of QR code 10 times every second
+          aspectRatio: 1,
+        },
+        (decodedText) => {
+          onResultDebounced(decodedText); // Debounce is bypassed only after a 2-sec quiet period (i.e. no QR code detected for 2 seconds)
+          wakeCameraAndScheduleSleep();
+        },
+        () => {} // Parse error on Html5Qrcode
+      )
+      .then(() => true)
+      .catch((e) => {
+        console.error("Unable to start Html5Qrcode:", e);
+        return false;
+      });
+
+    return () => {
+      cancelWakeCameraAndScheduleSleep();
+      isStarted.then((started) => {
+        if (started)
+          html5QrCode.stop().catch((e) => {
+            // Ignore this error as html5-qrcode library has a race condition issue causing error to always be thrown in React strict development mode
+            // Issue: https://github.com/mebjas/html5-qrcode/issues/500#issuecomment-1214363818
+            // Explanation: https://github.com/mebjas/html5-qrcode/pull/686#discussion_r1103632882
+            // html5-qrcode library may be fixed in a future PR: https://github.com/mebjas/html5-qrcode/pull/686
+            console.error("Unable to stop html5QrcodeScanner:", e);
+          });
+      });
+    };
+  }, [isAwake, isWindowFocused, cameraDevice]);
+
   /* When constraints are changed */
   useEffect(() => {
     wakeCameraAndScheduleSleep();
 
-    return () => scheduleSleepDebounced.cancel();
-  }, [constraints]);
+    return () => cancelWakeCameraAndScheduleSleep();
+  }, [cameraDevice]);
 
   /* When window is back in focus */
   useEffect(() => {
     if (isWindowFocused) wakeCameraAndScheduleSleep();
 
-    return () => scheduleSleepDebounced.cancel();
+    return () => cancelWakeCameraAndScheduleSleep();
   }, [isWindowFocused]);
 
   if (isAwake && isWindowFocused)
     return (
       <div className="relative">
-        <QrReader
-          key={JSON.stringify(constraints)}
-          constraints={constraints}
-          className="m-auto my-6 max-w-[60vh]" // QrReader is square, sized via width; Limit max width according to device height
-          videoStyle={{ borderRadius: "0.5rem", objectFit: "cover" }}
-          onResult={(res) => {
-            if (res) {
-              onResultDebounced(res.getText());
-              wakeCameraAndScheduleSleep(); // When scanning
-            }
-          }}
-        />
+        <div id="html5-qrcode" className="m-auto my-6 max-w-[60vh] rounded-lg overflow-hidden" ref={html5QrCodeRef} />
         <div className="absolute inset-0 flex justify-center">
           <img className="m-4" src="/images/qr-crosshair.svg" alt="qr visual guide" />
         </div>
@@ -63,19 +106,22 @@ export const CameraScanner: React.FC<CameraScannerProps> = ({ constraints, onRes
     );
   else if (!isAwake && isWindowFocused)
     return (
-      <div className="flex flex-col items-center my-32">
-        <Heading level="h2" className="text-2xl mb-4">
-          Camera timed out
-        </Heading>
-        <button
-          className={`btn hover:text-white inline-block
+      <div className="relative m-auto my-6 p-4 max-w-[60vh] rounded-2xl bg-gray-200">
+        <img className="w-full h-full" src="/images/qr-crosshair.svg" alt="qr visual guide" />
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          <Heading level="h2" className="text-2xl mb-4">
+            Camera timed out
+          </Heading>
+          <button
+            className={`btn hover:text-white inline-block
           text-white bg-primary hover:bg-primary-dark
           rounded-xl focus:ring
           transition-colors`}
-          onClick={() => wakeCameraAndScheduleSleep()} // User wake
-        >
-          Relaunch camera
-        </button>
+            onClick={() => wakeCameraAndScheduleSleep()} // User wake
+          >
+            Relaunch camera
+          </button>
+        </div>
       </div>
     );
   else
@@ -86,18 +132,12 @@ export const CameraScanner: React.FC<CameraScannerProps> = ({ constraints, onRes
     );
 };
 
-export type CustomMediaDeviceInfo = { device: MediaDeviceInfo; prettyLabel: string };
-
 export const getFilteredCameraDevices = async () => {
-  /* Request camera permissions from user */
-  await navigator.mediaDevices.getUserMedia({ video: true });
-
-  /* Enumerate all available cameras */
-  const mediaDevices = await navigator.mediaDevices.enumerateDevices();
-  const videoDevices = mediaDevices.filter((device) => device.kind === "videoinput");
+  /* Requests for camera permissions from user + enumerate all available cameras */
+  const cameras = await Html5Qrcode.getCameras();
 
   /* Sort by device label */
-  const sortedVideoDevices = videoDevices.sort((a, b) => {
+  const sortedVideoDevices = cameras.sort((a, b) => {
     if (a.label < b.label) return -1;
     else if (a.label > b.label) return 1;
     else return 0;

--- a/integration/qr-barcode-scanner.spec.ts
+++ b/integration/qr-barcode-scanner.spec.ts
@@ -2,8 +2,8 @@ import { Selector } from "testcafe";
 import { validateIframeText, validateIssuer } from "./helper";
 
 fixture("Scan QR page on Barcode Scanner mode").page`http://localhost:3000/qr`.beforeEach(async (t) => {
-  // const SwitchToBarcodeScannerLink = Selector("li").withText("Switch to Barcode Scanner");
-  // await t.click(SwitchToBarcodeScannerLink);
+  const SwitchToBarcodeScannerLink = Selector("li").withText("Switch to Barcode Scanner");
+  await t.click(SwitchToBarcodeScannerLink);
 });
 
 const StatusCheck = Selector("[data-testid='verification-checks']");

--- a/integration/qr-barcode-scanner.spec.ts
+++ b/integration/qr-barcode-scanner.spec.ts
@@ -1,10 +1,15 @@
 import { Selector } from "testcafe";
 import { validateIframeText, validateIssuer } from "./helper";
 
-fixture("Scan QR page on Barcode Scanner mode").page`http://localhost:3000/qr`.beforeEach(async (t) => {
-  const SwitchToBarcodeScannerLink = Selector("li").withText("Switch to Barcode Scanner");
-  await t.click(SwitchToBarcodeScannerLink);
-});
+fixture("Scan QR page on Barcode Scanner mode").page`http://localhost:3000/qr`
+  .skipJsErrors({
+    // FIXME: Temporarily ignore this JS error (as mentioned in components/verify/CameraScanner.tsx:L74)
+    message: /.*The play[(][)] request was interrupted because the media was removed from the document.*/gi,
+  })
+  .beforeEach(async (t) => {
+    const SwitchToBarcodeScannerLink = Selector("li").withText("Switch to Barcode Scanner");
+    await t.click(SwitchToBarcodeScannerLink);
+  });
 
 const StatusCheck = Selector("[data-testid='verification-checks']");
 const AlertContainer = Selector('[role="alert"]');

--- a/package-lock.json
+++ b/package-lock.json
@@ -6681,29 +6681,6 @@
       "integrity": "sha512-haGBC8noyA5BfjCRXRH+VIkHCDVW5iD5UX24P2nOdilwUxI4qWsattS/co8QBGq64XsNLRAMdM5pQUE3zxkF9Q==",
       "dev": true
     },
-    "@zxing/browser": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@zxing/browser/-/browser-0.0.7.tgz",
-      "integrity": "sha512-AepzMgDnD6EjxewqmXpHJsi4S3Gw9ilZJLIbTf6fWuWySEcHBodnGu3p7FWlgq1Sd5QyfPhTum5z3CBkkhMVng==",
-      "requires": {
-        "@zxing/text-encoding": "^0.9.0"
-      }
-    },
-    "@zxing/library": {
-      "version": "0.18.6",
-      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.18.6.tgz",
-      "integrity": "sha512-bulZ9JHoLFd9W36pi+7e7DnEYNJhljYjZ1UTsKPOoLMU3qtC+REHITeCRNx40zTRJZx18W5TBRXt5pq2Uopjsw==",
-      "requires": {
-        "@zxing/text-encoding": "~0.9.0",
-        "ts-custom-error": "^3.0.0"
-      }
-    },
-    "@zxing/text-encoding": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
-      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
-      "optional": true
-    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -9948,6 +9925,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "optional": true
     },
     "function-bind": {
@@ -10437,6 +10415,11 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "html5-qrcode": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/html5-qrcode/-/html5-qrcode-2.3.7.tgz",
+      "integrity": "sha512-Jmlok9Ynm49hgVXkdupWryf8o430proIFoQsRl1LmTg4Rq461W72omylR9yw9tsEMtswMEw3wacUM5y0agOBQA=="
     },
     "http-cache-semantics": {
       "version": "4.1.1",
@@ -14397,16 +14380,6 @@
         "tiny-warning": "^1.0.0"
       }
     },
-    "react-qr-reader": {
-      "version": "3.0.0-beta-1",
-      "resolved": "https://registry.npmjs.org/react-qr-reader/-/react-qr-reader-3.0.0-beta-1.tgz",
-      "integrity": "sha512-5HeFH9x/BlziRYQYGK2AeWS9WiKYZtGGMs9DXy3bcySTX3C9UJL9EwcPnWw8vlf7JP4FcrAlr1SnZ5nsWLQGyw==",
-      "requires": {
-        "@zxing/browser": "0.0.7",
-        "@zxing/library": "^0.18.3",
-        "rollup": "^2.67.2"
-      }
-    },
     "read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -14852,14 +14825,6 @@
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
-      }
-    },
-    "rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
-      "requires": {
-        "fsevents": "~2.3.2"
       }
     },
     "run-async": {
@@ -16334,11 +16299,6 @@
       "requires": {
         "utf8-byte-length": "^1.0.1"
       }
-    },
-    "ts-custom-error": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
-      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A=="
     },
     "ts-jest": {
       "version": "28.0.8",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@govtechsg/oa-verify": "^7.12.0",
     "@govtechsg/open-attestation": "^6.5.2",
     "axios": "^0.26.1",
+    "html5-qrcode": "^2.3.7",
     "lodash": "^4.17.21",
     "next": "^12.1.6",
     "next-mdx-remote": "^4.2.0",
@@ -32,7 +33,6 @@
     "react-dom": "17.0.2",
     "react-dropzone": "^12.0.5",
     "react-ga4": "^1.4.1",
-    "react-qr-reader": "^3.0.0-beta-1",
     "runtypes": "^6.6.0",
     "typesafe-actions": "^5.1.0"
   },

--- a/pages/qr.tsx
+++ b/pages/qr.tsx
@@ -66,7 +66,7 @@ const Qr: NextPage = () => {
       try {
         const availableCameras = await getFilteredCameraDevices();
 
-        dispatch({ type: "READY", availableDevices: ["Barcode Scanner", ...availableCameras] }); // FIXME: Since camera does not launch on first render for some devices (e.g. iPhone), workaround is to set Barcode Scanner as the default mode
+        dispatch({ type: "READY", availableDevices: [...availableCameras, "Barcode Scanner"] });
       } catch (e) {
         console.error(e);
 
@@ -149,7 +149,7 @@ const Qr: NextPage = () => {
             {selectedDevice === "Barcode Scanner" ? (
               <BarcodeScanner onResult={onResult} />
             ) : (
-              <CameraScanner constraints={{ deviceId: selectedDevice.device.deviceId }} onResult={onResult} />
+              <CameraScanner cameraDevice={selectedDevice} onResult={onResult} />
             )}
 
             <p className="m-0">


### PR DESCRIPTION
## Context

QR camera scanner did not start automatically for some devices (e.g. iPhone) when the `react-qr-reader` library was used

## What does this PR do

- Replace ~~`react-qr-reader`~~ with `html5-qrcode`
- QR camera scanning is now the default mode

## Caveat

A race condition happens with the`html5-qrcode` library when React strict mode is enabled because [`useEffect()` is run twice](https://reactjs.org/docs/strict-mode.html#ensuring-reusable-state). We have the correct cleanup code `.stop()` but it seems to be called before the first render completes.

> To help surface these issues, React 18 introduces a new development-only check to Strict Mode. This new check will automatically unmount and remount every component, whenever a component mounts for the first time, restoring the previous state on the second mount.

As such, a temporary measure would be:
- Just ignore this JS error as it will always be thrown in React strict development mode
  ![image](https://user-images.githubusercontent.com/37650399/223067706-b91f526c-addd-4397-b177-57e1a0d951cf.png)
- Issue: `https://github.com/mebjas/html5-qrcode/issues/500#issuecomment-1214363818` <!-- Link to issue without creating a reference -->
- Explanation and possible fix by library maintainers in the future: `https://github.com/mebjas/html5-qrcode/pull/686#discussion_r1103632882` <!-- Link to issue without creating a reference -->