### PR TITLE
feat: show popup if user agent is iOS and a non-safari browser

### DIFF
--- a/components/figure/Renderer.tsx
+++ b/components/figure/Renderer.tsx
@@ -52,10 +52,10 @@ const Renderer: React.FC<RendererProps> = ({ document, rawDocument }) => {
 
   const handlePrint = useCallback(async () => {
     const ua = window.navigator.userAgent;
-    const isIOS = /iPad|iPhone|iPod/.test(ua);
+    const isIOS = /iPad|iPhone|iPod/i.test(ua);
     // List of common browsers installable from app store
-    const isNotSafari = /CriOS|FxiOS|EdgiOS|YaBrowser|OPT|OPR/.test(ua);
-    const isSamsungBrowser = ua.includes("SamsungBrowser");
+    const isNotSafari = /CriOS|FxiOS|EdgiOS|YaBrowser|OPT|OPR/i.test(ua);
+    const isSamsungBrowser = /SamsungBrowser/i.test(ua);
     // https://stackoverflow.com/questions/36523448/how-do-i-tell-if-a-user-is-using-brave-as-their-browser/60954062#60954062
     // no typings for browser-specific fields - https://github.com/microsoft/TypeScript/issues/41532
     const isBraveBrowser =

--- a/components/figure/Renderer.tsx
+++ b/components/figure/Renderer.tsx
@@ -53,7 +53,15 @@ const Renderer: React.FC<RendererProps> = ({ document, rawDocument }) => {
   const handlePrint = useCallback(() => {
     var ua = window.navigator.userAgent;
     var iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i);
-    var isNotSafari = ua.includes("CriOS") && ua.includes("FxiOS");
+    // List of common browsers installable from app store
+    // https://www.whatismybrowser.com/guides/the-latest-user-agent/
+    var isNotSafari =
+      ua.includes("CriOS") &&
+      ua.includes("FxiOS") &&
+      ua.includes("EdgiOS") &&
+      ua.includes("Brave") &&
+      ua.includes("YaBrowser") &&
+      ua.includes("OPR");
 
     if ((iOS && isNotSafari) || navigator.userAgent.includes("SamsungBrowser")) {
       alert(

--- a/components/figure/Renderer.tsx
+++ b/components/figure/Renderer.tsx
@@ -51,11 +51,11 @@ const Renderer: React.FC<RendererProps> = ({ document, rawDocument }) => {
   }, []);
 
   const handlePrint = useCallback(() => {
-    if (
-      navigator.userAgent.includes("SamsungBrowser") ||
-      navigator.userAgent.includes("CriOS") ||
-      navigator.userAgent.includes("FxiOS")
-    ) {
+    var ua = window.navigator.userAgent;
+    var iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i);
+    var isNotSafari = ua.includes("CriOS") && ua.includes("FxiOS");
+
+    if ((iOS && isNotSafari) || navigator.userAgent.includes("SamsungBrowser")) {
       alert(
         "Printing this document is not optimised on your device.\nFor the best result, use: \n- Chrome on Android devices \n- Safari on IOS devices \n- Any major browsers on desktop"
       );

--- a/components/figure/Renderer.tsx
+++ b/components/figure/Renderer.tsx
@@ -52,18 +52,12 @@ const Renderer: React.FC<RendererProps> = ({ document, rawDocument }) => {
 
   const handlePrint = useCallback(() => {
     var ua = window.navigator.userAgent;
-    var iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i);
+    const isIOS = /iPad|iPhone|iPod/.test(ua);
     // List of common browsers installable from app store
-    var isNotSafari =
-      ua.includes("CriOS") ||
-      ua.includes("FxiOS") ||
-      ua.includes("EdgiOS") ||
-      ua.includes("Brave") ||
-      ua.includes("YaBrowser") ||
-      ua.includes("OPT") ||
-      ua.includes("OPR");
+    const isNotSafari = /CriOS|FxiOS|EdgiOS|Brave|YaBrowser|OPT|OPR/.test(ua);
+    const isSamsungBrowser = ua.includes("SamsungBrowser");
 
-    if ((iOS && isNotSafari) || navigator.userAgent.includes("SamsungBrowser")) {
+    if ((isIOS && isNotSafari) || isSamsungBrowser) {
       alert(
         "Printing this document is not optimised on your device.\nFor the best result, use: \n- Chrome on Android devices \n- Safari on IOS devices \n- Any major browsers on desktop"
       );

--- a/components/figure/Renderer.tsx
+++ b/components/figure/Renderer.tsx
@@ -54,13 +54,13 @@ const Renderer: React.FC<RendererProps> = ({ document, rawDocument }) => {
     var ua = window.navigator.userAgent;
     var iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i);
     // List of common browsers installable from app store
-    // https://www.whatismybrowser.com/guides/the-latest-user-agent/
     var isNotSafari =
-      ua.includes("CriOS") &&
-      ua.includes("FxiOS") &&
-      ua.includes("EdgiOS") &&
-      ua.includes("Brave") &&
-      ua.includes("YaBrowser") &&
+      ua.includes("CriOS") ||
+      ua.includes("FxiOS") ||
+      ua.includes("EdgiOS") ||
+      ua.includes("Brave") ||
+      ua.includes("YaBrowser") ||
+      ua.includes("OPT") ||
       ua.includes("OPR");
 
     if ((iOS && isNotSafari) || navigator.userAgent.includes("SamsungBrowser")) {

--- a/components/figure/Renderer.tsx
+++ b/components/figure/Renderer.tsx
@@ -50,14 +50,20 @@ const Renderer: React.FC<RendererProps> = ({ document, rawDocument }) => {
     }
   }, []);
 
-  const handlePrint = useCallback(() => {
+  const handlePrint = useCallback(async () => {
     const ua = window.navigator.userAgent;
     const isIOS = /iPad|iPhone|iPod/.test(ua);
     // List of common browsers installable from app store
-    const isNotSafari = /CriOS|FxiOS|EdgiOS|Brave|YaBrowser|OPT|OPR/.test(ua);
+    const isNotSafari = /CriOS|FxiOS|EdgiOS|YaBrowser|OPT|OPR/.test(ua);
     const isSamsungBrowser = ua.includes("SamsungBrowser");
+    // https://stackoverflow.com/questions/36523448/how-do-i-tell-if-a-user-is-using-brave-as-their-browser/60954062#60954062
+    // no typings for browser-specific fields - https://github.com/microsoft/TypeScript/issues/41532
+    const isBraveBrowser =
+      ((window.navigator as any).brave && (await (window.navigator as any).brave.isBrave())) || false;
 
-    if ((isIOS && isNotSafari) || isSamsungBrowser) {
+    const isUnsupportedBrowser = (isIOS && (isNotSafari || isBraveBrowser)) || isSamsungBrowser;
+
+    if (isUnsupportedBrowser) {
       alert(
         "Printing this document is not optimised on your device.\nFor the best result, use: \n- Chrome on Android devices \n- Safari on IOS devices \n- Any major browsers on desktop"
       );

--- a/components/figure/Renderer.tsx
+++ b/components/figure/Renderer.tsx
@@ -51,7 +51,7 @@ const Renderer: React.FC<RendererProps> = ({ document, rawDocument }) => {
   }, []);
 
   const handlePrint = useCallback(() => {
-    var ua = window.navigator.userAgent;
+    const ua = window.navigator.userAgent;
     const isIOS = /iPad|iPhone|iPod/.test(ua);
     // List of common browsers installable from app store
     const isNotSafari = /CriOS|FxiOS|EdgiOS|Brave|YaBrowser|OPT|OPR/.test(ua);


### PR DESCRIPTION
## Context 
- Currently there are no way to fix the print issue for non-safari browsers on iOS devices ([reference: previous PR fix](https://github.com/Open-Attestation/verify.gov.sg/pull/140)). 
- Only Safari browser is able to show the correct behavior of print preview on iOS 
- We also found out that all other browsers on iOS (e.g. Brave, Edge, Chrome, Firefox) are having the same issue as well. Hence, this PR is to enable the alert on other non-safari browsers as well.
- Related tickets for future tracking - https://bugs.chromium.org/p/chromium/issues/detail?id=1421679 , https://bugs.chromium.org/p/chromium/issues/detail?id=1021034 

## What this PR does
- Instead of showing pop up for iOS chrome and firefox, we are enabling the alert for all **non-safari browsers on iOS**

### Keywords of non-safari browser

| Browser  | Filter keyword | Description | Alert shown? |
| ----------------- | ------------- | ------------- |  ------------- | 
| Chrome iOS         | CriOs  |  https://www.whatismybrowser.com/guides/the-latest-user-agent/chrome | ✅ |
| Firefox iOS           | FxiOS    | https://www.whatismybrowser.com/guides/the-latest-user-agent/firefox | ✅ |
| Edge iOS              | EdgiOS   | https://www.whatismybrowser.com/guides/the-latest-user-agent/edge | ✅ |
| Brave Browser     | Brave  | ~~No specific keyword to identify the user agent; the keyword `Brave` does not show in the `user agent` when I run on my iphone. (But I am adding it into the list of filter as ["Brave" appears on other browsing devices](https://explore.whatismybrowser.com/useragents/explore/software_name/brave/), just not iOS mobile, to be safe)~~ Checks done via window.navigator() - https://stackoverflow.com/questions/36523448/how-do-i-tell-if-a-user-is-using-brave-as-their-browser/60954062#60954062 | ✅ |
| Yandex Browser. | YaBrowser  | https://www.whatismybrowser.com/guides/the-latest-user-agent/yandex-browser | ✅ |
| Opera                  | OPT, OPR  | Although [whatismybrowser states it as `OPR`](https://www.whatismybrowser.com/guides/the-latest-user-agent/opera), the actual user agent shows `OPT` (Opera Touch) on my iphone. Hence, added both `OPT` and `OPR` to be safe | ✅ |
