### PR TITLE
feat: 184378133 analytics for healthcerts verifications via qr scanner

### DIFF
--- a/components/verify/CameraScanner.tsx
+++ b/components/verify/CameraScanner.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Html5Qrcode, Html5QrcodeSupportedFormats } from "html5-qrcode";
 import { CameraDevice } from "html5-qrcode/camera/core";
 import debounce from "lodash/debounce";
@@ -11,7 +11,7 @@ const FIVE_MINUTES = 5 * 60 * 1000;
 export type CustomMediaDeviceInfo = { device: CameraDevice; prettyLabel: string };
 
 interface CameraScannerProps {
-  cameraDevice: CustomMediaDeviceInfo;
+  cameraDevice?: CustomMediaDeviceInfo;
   onResult: (url: string) => void;
 }
 
@@ -49,7 +49,7 @@ export const CameraScanner: React.FC<CameraScannerProps> = ({ cameraDevice, onRe
 
     const isStarted = html5QrCode
       .start(
-        cameraDevice.device.id,
+        cameraDevice?.device.id || { facingMode: "environment" },
         {
           fps: 10, // Scans for presence of QR code 10 times every second
           aspectRatio: 1,

--- a/pages/qr.tsx
+++ b/pages/qr.tsx
@@ -85,8 +85,10 @@ const Qr: NextPage = () => {
   const onResult = (url: string) => {
     try {
       const parsedUrl = new URL(url);
+      const SITE_URL = process.env.SITE_URL; // See "next.config.js"
+      const allowedOrigins = [SITE_URL, "https://www.verify.gov.sg"];
 
-      if (parsedUrl.origin !== "https://www.verify.gov.sg") {
+      if (!allowedOrigins.some((origin) => origin === parsedUrl.origin)) {
         throw new CodedError("InvalidDocumentError", "Invalid Verify QR, please try again");
       }
 

--- a/pages/qr.tsx
+++ b/pages/qr.tsx
@@ -11,43 +11,34 @@ import BarcodeScanner from "@components/verify/BarcodeScanner";
 import { CodedError } from "@utils/coded-error";
 import { qrErrorHandler } from "@utils/error-handler";
 import { useWindowFocus } from "@utils/window-focus-hook";
+import { useRouterQuery } from "@utils/router-query-hook";
 
-type AvailableDevice = CustomMediaDeviceInfo | "Barcode Scanner";
+const barcodeScanner = { prettyLabel: "Barcode Scanner" } as const;
+
+type BarcodeScanner = typeof barcodeScanner;
+type AvailableDevices = (CustomMediaDeviceInfo | BarcodeScanner)[];
 
 interface State {
-  isReady: boolean;
   status: StatusProps;
-  availableDevices: AvailableDevice[];
-  selectedDevice: AvailableDevice;
+  availableDevices?: AvailableDevices;
 }
 
 type Action =
-  | { type: "READY"; availableDevices: AvailableDevice[] }
-  | { type: "SCAN_WITH_CAMERA"; selectedDevice: CustomMediaDeviceInfo }
-  | { type: "SCAN_WITH_BARCODE" }
+  | { type: "SET_AVAILABLE_DEVICES"; availableDevices: AvailableDevices }
   | { type: "STATUS_MESSAGE"; status: StatusProps }
   | { type: "RESET_STATUS_MESSAGE" };
 
 const initialState: State = {
-  isReady: false,
   status: { type: "LOADING", message: <>Looking for available cameras...</> },
-  availableDevices: ["Barcode Scanner"],
-  selectedDevice: "Barcode Scanner",
 };
 
 const reducer: Reducer<State, Action> = (state, action) => {
   switch (action.type) {
-    case "READY":
+    case "SET_AVAILABLE_DEVICES":
       return {
-        isReady: true,
         status: { type: "NIL" },
         availableDevices: action.availableDevices,
-        selectedDevice: action.availableDevices[0],
       };
-    case "SCAN_WITH_CAMERA":
-      return { ...state, selectedDevice: action.selectedDevice, status: { type: "NIL" } };
-    case "SCAN_WITH_BARCODE":
-      return { ...state, selectedDevice: "Barcode Scanner", status: { type: "NIL" } };
     case "STATUS_MESSAGE":
       return { ...state, status: action.status };
     case "RESET_STATUS_MESSAGE":
@@ -59,23 +50,38 @@ const reducer: Reducer<State, Action> = (state, action) => {
 
 const Qr: NextPage = () => {
   const isWindowFocused = useWindowFocus();
-  const [{ isReady, status, availableDevices, selectedDevice }, dispatch] = useReducer(reducer, initialState);
+  const [selectedDevicePrettyLabel, setSelectedDevicePrettyLabel, isRouterReady] = useRouterQuery("device");
+  const [{ status, availableDevices }, dispatch] = useReducer(reducer, initialState);
+  const isReady = !!availableDevices && !!selectedDevicePrettyLabel;
 
+  /* Initialisation on router ready: Search for available cameras */
   useEffect(() => {
+    if (!isRouterReady) return;
+
     (async () => {
       try {
         const availableCameras = await getFilteredCameraDevices();
+        const availableDevices = [...availableCameras, barcodeScanner];
 
-        dispatch({ type: "READY", availableDevices: [...availableCameras, "Barcode Scanner"] });
+        dispatch({ type: "SET_AVAILABLE_DEVICES", availableDevices });
+
+        /* If no device or an unknown device is selected, default to first device */
+        if (
+          !selectedDevicePrettyLabel ||
+          !availableDevices.some((device) => device.prettyLabel === selectedDevicePrettyLabel)
+        ) {
+          setSelectedDevicePrettyLabel(availableDevices[0].prettyLabel);
+        }
       } catch (e) {
         console.error(e);
 
         /* Unable to get cameras: Fallback to "Barcode Scanner" */
-        dispatch({ type: "READY", availableDevices: ["Barcode Scanner"] });
+        dispatch({ type: "SET_AVAILABLE_DEVICES", availableDevices: [barcodeScanner] });
         dispatch({ type: "STATUS_MESSAGE", status: qrErrorHandler(e) });
+        setSelectedDevicePrettyLabel(barcodeScanner.prettyLabel);
       }
     })();
-  }, [isReady]);
+  }, [isRouterReady]);
 
   const onResult = (url: string) => {
     try {
@@ -132,24 +138,28 @@ const Qr: NextPage = () => {
 
             {/* Mode selection */}
             <div className="pb-4">
-              Current scan mode:{" "}
-              <span className="font-bold">
-                {selectedDevice === "Barcode Scanner" ? selectedDevice : selectedDevice.prettyLabel}
-              </span>
+              Current scan mode: <span className="font-bold">{selectedDevicePrettyLabel}</span>
             </div>
             <ul className="flex flex-wrap justify-center gap-2">
               <DeviceSelection
                 availableDevices={availableDevices}
-                selectedDevice={selectedDevice}
-                dispatch={dispatch}
+                selectedDevice={availableDevices.find((device) => device.prettyLabel === selectedDevicePrettyLabel)}
+                onSelectedDevice={(prettyLabel) => {
+                  setSelectedDevicePrettyLabel(prettyLabel);
+                }}
               />
             </ul>
 
             {/* Camera or barcode scanner */}
-            {selectedDevice === "Barcode Scanner" ? (
+            {selectedDevicePrettyLabel === barcodeScanner.prettyLabel ? (
               <BarcodeScanner onResult={onResult} />
             ) : (
-              <CameraScanner cameraDevice={selectedDevice} onResult={onResult} />
+              <CameraScanner
+                cameraDevice={availableDevices
+                  .filter((device): device is CustomMediaDeviceInfo => device !== barcodeScanner)
+                  .find((camera) => camera.prettyLabel === selectedDevicePrettyLabel)}
+                onResult={onResult}
+              />
             )}
 
             <p className="m-0">
@@ -170,33 +180,28 @@ const Qr: NextPage = () => {
 export default Qr;
 
 interface DeviceSelectionProps {
-  availableDevices: AvailableDevice[];
-  selectedDevice: AvailableDevice;
-  dispatch: Dispatch<Action>;
+  availableDevices: (CustomMediaDeviceInfo | BarcodeScanner)[];
+  selectedDevice?: CustomMediaDeviceInfo | BarcodeScanner;
+  onSelectedDevice: (selectedDevicePrettyLabel: string) => void;
 }
 
-const DeviceSelection: React.FC<DeviceSelectionProps> = ({ availableDevices, selectedDevice, dispatch }) => (
+const DeviceSelection: React.FC<DeviceSelectionProps> = ({ availableDevices, selectedDevice, onSelectedDevice }) => (
   <>
     {availableDevices
-      .filter((device) => selectedDevice !== device)
+      .filter((device) => device !== selectedDevice)
       .map((device, i) => (
         <li
           key={i}
           className="text-blue-600 underline cursor-pointer"
-          onClick={
-            device === "Barcode Scanner"
-              ? () => {
-                  dispatch({ type: "SCAN_WITH_BARCODE" });
-                }
-              : () => dispatch({ type: "SCAN_WITH_CAMERA", selectedDevice: device })
-          }
+          onClick={() => {
+            onSelectedDevice(device.prettyLabel);
+          }}
         >
-          {device === "Barcode Scanner" ? `Switch to Barcode Scanner` : `Switch to ${device.prettyLabel}`}
+          Switch to {device.prettyLabel}
         </li>
       ))}
   </>
 );
-
 const BlurWhenUnfocused: React.FC<{ isWindowFocused: boolean }> = ({ isWindowFocused }) =>
   isWindowFocused ? null : (
     <div className="absolute inset-0 flex items-center justify-center rounded-lg backdrop-blur-sm">

--- a/utils/router-query-hook.ts
+++ b/utils/router-query-hook.ts
@@ -1,0 +1,16 @@
+import { useRouter } from "next/router";
+
+export const useRouterQuery: (key: string) => [string, (value: string) => void, boolean] = (key) => {
+  const router = useRouter();
+  const { isReady } = router;
+
+  const value = router.query[key] || "";
+
+  const setValue = (value: string) => {
+    router.replace({
+      query: { ...router.query, [key]: value },
+    });
+  };
+
+  return [Array.isArray(value) ? value[0] : value, setValue, isReady];
+};


### PR DESCRIPTION
## What does this PR do?

### Allow analytics of successful/unsuccessful verifications of HealthCerts indirectly by:
- Implementing QR scanner device selection via the `device` query param (e.g. `/qr?device=Back+Camera`, `/qr?device=Barcode+Scanner`, etc.)
- Currently, Google Analytics already keeps track of a `Page Referrer` property (i.e. `document.referrer`) on every page visit. By visiting `/verify` site, we will know which page the user originated from
- As such, we are riding on this existing behaviour by including a `device` query parameter to the URL so we can identify the scanner device (if any)
- Screenshot of Tag Assistant capturing Google Analytics event:
  ![image](https://user-images.githubusercontent.com/37650399/228168515-99a0c36d-32cb-479f-9864-00a70f16baee.png)

### Update whitelisted URLs for QR scanning:
- `[SITE_URL, "https://www.verify.gov.sg"]` (SITE_URL is set in `next.config.js`)
- This will allow localhost or deploy preview QRs, especially useful for testing but will have no effect on production

## Try it out
1. Go to Tag Assistant: https://tagassistant.google.com/
2. Add this domain: https://deploy-preview-171--verify-gov-sg.netlify.app/qr
3. Click Connect
4. In the newly opened tab, scan this QR: <img src="https://user-images.githubusercontent.com/37650399/228171955-717a3d62-d495-4b68-a13a-c90182bc84c8.png" width="200px" />
6. After verification is complete, go back to Tag Assistant tab
7. Click on `certificate_verified` event and inspect the properties - these are the properties sent along with each analytics event