### PR TITLE
chore: update circleci to pass chromedriver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  browser-tools: circleci/browser-tools@1.4.3
+  browser-tools: circleci/browser-tools@1.4.5
 workflows:
   version: 2
   commit:


### PR DESCRIPTION
## Context 
- Pipeline failing because chromdriver fails to install; Related to this https://discuss.circleci.com/t/circleci-browser-tools-failing-on-chromedriver-116-x/49119/2 , seems to be resolved with circleci/browser-tools@1.4.5

## What this PR does
- Update browser-tools to 1.4.5