### PR TITLE
chore: use SITE_URL environment variable

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,17 +1,6 @@
 const { generateHeaders } = require("./next.headers");
 
-let SITE_URL;
-
 const withTM = require("next-transpile-modules")(["@govtechsg/sgds-masthead-react"]);
-
-// Env variables by Netlify (https://docs.netlify.com/configure-builds/environment-variables/#build-metadata)
-if (process.env.CONTEXT !== "production" && process.env.DEPLOY_PRIME_URL) {
-  SITE_URL = process.env.DEPLOY_PRIME_URL;
-} else if (process.env.NODE_ENV !== "production") {
-  SITE_URL = `http://localhost:3000`;
-} else {
-  SITE_URL = "https://www.verify.gov.sg";
-}
 
 // Env variables by Netlify (https://docs.netlify.com/configure-builds/environment-variables/#git-metadata)
 const COMMIT_REF = process.env.COMMIT_REF || "v1.0.0";
@@ -23,7 +12,7 @@ const nextConfig = withTM({
   output: "standalone",
   env: {
     CONTEXT: process.env.CONTEXT,
-    SITE_URL,
+    SITE_URL: process.env.SITE_URL,
     COMMIT_REF,
     BUILD_DATE: new Date().toISOString(),
   },


### PR DESCRIPTION
## Context
- Since we have moved away from Netlify, we no longer have access to the Netlify build metadata's `CONTEXT`
- This directly impacts our [allowedOrigins whitelisting](https://github.com/Open-Attestation/verify.gov.sg/blob/master/pages/qr.tsx#L90)

## What this PR does
- Removed Netlify related metadata and use `SITE_URL` from our environment variable directly